### PR TITLE
Update the discount badge

### DIFF
--- a/react/DiscountBadge.js
+++ b/react/DiscountBadge.js
@@ -8,18 +8,20 @@ import PropTypes from 'prop-types'
 */
 class DiscountBadge extends Component {
   /**
-  * This method calculates the discount tax by the selling and list prices.
+  * This method calculates the discount tax.
+  * @param {number} listPrice - The product's price
+  * @param {number} sellingPrice - The product's price with discount
   */
-  calculateDiscountTax() {
-    const { listPrice, sellingPrice } = this.props
+  calculateDiscountTax(listPrice, sellingPrice) {
     return (listPrice - sellingPrice) / listPrice
   }
 
   render() {
-    const percent = this.calculateDiscountTax()
+    const { listPrice, sellingPrice, label } = this.props
+    const percent = this.calculateDiscountTax(listPrice, sellingPrice)
     return (percent !== 0) &&
       <div className="f7 dark-gray absolute right-0 pa2-s bg-white">
-        <FormattedNumber value={percent} style="percent" /> { this.props.label }
+        <FormattedNumber value={percent} style="percent" /> { label }
       </div>
   }
 }

--- a/react/DiscountBadge.js
+++ b/react/DiscountBadge.js
@@ -21,6 +21,7 @@ class DiscountBadge extends Component {
     const percent = this.calculateDiscountTax(listPrice, sellingPrice)
     return (percent !== 0) &&
       <div className="f7 dark-gray absolute right-0 pa2-s bg-white">
+        { label === '' && '-' }
         <FormattedNumber value={percent} style="percent" /> { label }
       </div>
   }
@@ -32,7 +33,7 @@ DiscountBadge.propTypes = {
   /** The product's price with discount */
   sellingPrice: PropTypes.number.isRequired,
   /** The label to track the discount percent */
-  label: PropTypes.string
+  label: PropTypes.string,
 }
 
 DiscountBadge.defaultProps = {

--- a/react/DiscountBadge.js
+++ b/react/DiscountBadge.js
@@ -7,11 +7,6 @@ import PropTypes from 'prop-types'
 * and calculates the discount percent to show it in the product's sumary.
 */
 class DiscountBadge extends Component {
-  /**
-  * This method calculates the discount tax.
-  * @param {number} listPrice - The product's price
-  * @param {number} sellingPrice - The product's price with discount
-  */
   calculateDiscountTax(listPrice, sellingPrice) {
     return (listPrice - sellingPrice) / listPrice
   }

--- a/react/DiscountBadge.js
+++ b/react/DiscountBadge.js
@@ -32,11 +32,11 @@ DiscountBadge.propTypes = {
   /** The product's price with discount */
   sellingPrice: PropTypes.number.isRequired,
   /** The label to track the discount percent */
-  label: PropTypes.string,
+  label: PropTypes.string
 }
 
 DiscountBadge.defaultProps = {
-  label: 'OFF',
+  label: '',
 }
 
 export default DiscountBadge

--- a/react/first.js
+++ b/react/first.js
@@ -2,10 +2,15 @@ import React from 'react'
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl'
 import DiscountBadge from './DiscountBadge'
 
+const product = {
+  listPrice: 200,
+  sellingPrice: 150,
+}
+
 const FirstStep = () =>
   <div>
     <div className="relative dib">
-      <DiscountBadge listPrice={200} sellingPrice={20} />
+      <DiscountBadge listPrice={product.listPrice} sellingPrice={product.sellingPrice} />
       <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSd0cHfPOO0tneOT0AH3UDs7BumkdOVHZtv4DL55dFtInS2q8mi"/>
     </div>
     <h2>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the discount badge and fix the discount badge mock.

#### What problem is this solving?
Update the calculate discount tax method to receive the listPrice and sellingPrice as params instead of get them from the props. And update the label default value to an empty string instead of 'OFF'. Also, add a negative signal before the percent if the label isn't given. In the mock, add a json object to get the discount badge values from it.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
