### PR TITLE
Add details button and it's configuration

### DIFF
--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -36,8 +36,9 @@ class ProductSummary extends Component {
       showInstallments,
       showBadge,
       badgeText,
+      hideDetailsButton,
       hideBuyButton,
-      showButtonOnHover,
+      showButtonsOnHover,
     } = this.props
 
     return (
@@ -84,11 +85,20 @@ class ProductSummary extends Component {
                   showInstallments={showInstallments} />
               </div>
             </div>
-            <div className="pv2">
-              <div className={`${(!showButtonOnHover || (showButtonOnHover && this.state.isHovering)) ? 'db' : 'dn'}`}>
+            <div className="pt4">
+              <div className={`cf ph4 ${(!showButtonsOnHover || (showButtonsOnHover && this.state.isHovering)) ? 'db' : 'dn'}`}>
+                {!hideDetailsButton && (
+                  <div className={`${(!hideBuyButton && 'fl') || ''}`}>
+                    <Button onClick={this.handleClick} block>
+                      <FormattedMessage id="details" />
+                    </Button>
+                  </div>
+                )}
                 {!hideBuyButton && (
                   // TODO: Use the buy button component
-                  <Button primary onClick={event => event.stopPropagation()}>BUY THIS AWESOME PRODUCT</Button>
+                  <div className={`${(!hideDetailsButton && 'fr') || ''} ${hideDetailsButton && 'w-100'}`}>
+                    <Button primary onClick={event => event.stopPropagation()} block>BUY</Button>
+                  </div>
                 )}
               </div>
             </div>
@@ -129,10 +139,12 @@ ProductSummary.propTypes = {
   showBadge: PropTypes.bool,
   /** Text shown on badge */
   badgeText: PropTypes.string,
-  /** Hides the buy button completely . If active, the button will not be shown in any condition */
+  /** Hides the details button completely */
+  hideDetailsButton: PropTypes.bool,
+  /** Hides the buy button completely. If active, the button will not be shown in any condition */
   hideBuyButton: PropTypes.bool,
   /** Defines if the button is shown only if the mouse is on the summary */
-  showButtonOnHover: PropTypes.bool,
+  showButtonsOnHover: PropTypes.bool,
 }
 
 ProductSummary.schema = {
@@ -160,13 +172,17 @@ ProductSummary.schema = {
       type: 'string',
       title: 'Badge\'s text',
     },
+    hideDetailsButton: {
+      type: 'boolean',
+      title: 'Hides the details button completely',
+    },
     hideBuyButton: {
       type: 'boolean',
       title: 'Hides the buy button completely',
     },
-    showButtonOnHover: {
+    showButtonsOnHover: {
       type: 'boolean',
-      title: 'Show the buy button only on hover (if not hidden)',
+      title: 'Show the buttons only on hover (if not hidden)',
     },
   },
 }

--- a/react/index.js
+++ b/react/index.js
@@ -20,6 +20,7 @@ const props = {
   showInstallments: false,
   showLabels: true,
   showBadge: true,
+  hideDetailsButton: false,
   hideBuyButton: false,
   showOnHover: false,
 }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -2,5 +2,6 @@
   "pricing.installment-display": "or up to {installments}X of {installmentPrice}",
   "pricing.from": "from:",
   "pricing.to": "to:",
-  "loading": "Loading…"
+  "loading": "Loading…",
+  "details": "Details"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -2,5 +2,6 @@
   "pricing.installment-display": "o hasta {installments}X de {installmentPrice}",
   "pricing.from": "de:",
   "pricing.to": "por:",
-  "loading": "Cargando…"
+  "loading": "Cargando…",
+  "details": "Detalles"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -2,5 +2,6 @@
   "pricing.installment-display": "ou até {installments}X de {installmentPrice}",
   "pricing.from": "de:",
   "pricing.to": "por:",
-  "loading": "Carregando…"
+  "loading": "Carregando…",
+  "details": "Detalhes"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add the 'details' button and configuration to the Summary Component. We analyzed the product summaries of some stores and saw that the details button is relevant.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Incomplete Summary.

#### How should this be manually tested?
Access the [usage url](https://estacio--storecomponents.myvtex.com/) and see the button working. Select the Product Summary to edit its properties and edit the hide buttons configurations.

#### Screenshots or example usage
Screenshots:
![captura de tela de 2018-04-11 15-59-42](https://user-images.githubusercontent.com/15948386/38639871-e7a37b06-3da8-11e8-9fcd-77716c5af5c2.png)

![image](https://user-images.githubusercontent.com/15948386/38639673-5355960a-3da8-11e8-8289-f211a1f1a76f.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
