### PR TITLE
Add the component dynamic schema props

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ node_js:
 before_install: 
   - cd react
 install: 
-  - npm install
+  - yarn
 script: 
-  - npm t
+  - yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-* Do not shows list price when equals selling price
+* Does not show list price when it is equal to selling price
 * Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
 * Add default schema props to the _Product Summary_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * **Component** Create the VTEX Store Component _Product Summary_
+* Added the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
+
+### Fixed
+
+* Do not shows list price when equals selling price
+* Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
+* Added default schema props to the _Product Summary_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.1.0] - 2018-04-24
-
 ### Added
 
 * **Component** Create the VTEX Store Component _Product Summary_
@@ -19,3 +17,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Do not shows list price when equals selling price
 * Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
 * Add default schema props to the _Product Summary_
+
+## [0.1.0] - 2018-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-* **Component** Create the VTEX Store Component _Product Summary_
 * Add the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
 
 ### Fixed
@@ -19,3 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add default schema props to the _Product Summary_
 
 ## [0.1.0] - 2018-04-24
+
+### Added
+
+* **Component** Create the VTEX Store Component _Product Summary_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * **Component** Create the VTEX Store Component _Product Summary_
-* Added the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
+* Add the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
 
 ### Fixed
 
 * Do not shows list price when equals selling price
 * Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
-* Added default schema props to the _Product Summary_
+* Add default schema props to the _Product Summary_

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import { isMobile } from 'react-device-detect'
-import cloneDeep from 'lodash/cloneDeep'
 
 import BuyButton from '@vtex/buy-button'
 
@@ -223,11 +222,11 @@ const defaultSchema = {
 }
 
 ProductSummary.getSchema = ({ hideBuyButton }) => {
-  const dynamicSchema = cloneDeep(defaultSchema)
-  if (hideBuyButton) {
-    delete dynamicSchema.properties.showButtonOnHover
+  const { showButtonOnHover, ...rest } = defaultSchema.properties
+  return {
+    ...defaultSchema,
+    properties: Object.assign(rest, hideBuyButton ? {} : { showButtonOnHover }),
   }
-  return dynamicSchema
 }
 
 export default ProductSummary

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import { isMobile } from 'react-device-detect'
+import cloneDeep from 'lodash/cloneDeep'
 
 import BuyButton from '@vtex/buy-button'
 
@@ -167,7 +168,16 @@ ProductSummary.propTypes = {
   showButtonOnHover: PropTypes.bool,
 }
 
-ProductSummary.schema = {
+ProductSummary.defaultProps = {
+  showListPrice: true,
+  showInstallments: true,
+  showLabels: true,
+  showBadge: true,
+  hideBuyButton: false,
+  showOnHover: false,
+}
+
+const defaultSchema = {
   title: 'Product Summary',
   description: 'The product summary showing the main product informations',
   type: 'object',
@@ -207,18 +217,17 @@ ProductSummary.schema = {
     },
     showButtonOnHover: {
       type: 'boolean',
-      title: 'Show the buy button only on hover (if not hidden)',
+      title: 'Show the buy button only on hover',
     },
   },
 }
 
-ProductSummary.defaultProps = {
-  showListPrice: true,
-  showInstallments: true,
-  showLabels: true,
-  showBadge: true,
-  hideBuyButton: false,
-  showOnHover: false,
+ProductSummary.getSchema = ({ hideBuyButton }) => {
+  const dynamicSchema = cloneDeep(defaultSchema)
+  if (hideBuyButton) {
+    delete dynamicSchema.properties.showButtonOnHover
+  }
+  return dynamicSchema
 }
 
 export default ProductSummary

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -225,7 +225,10 @@ ProductSummary.getSchema = ({ hideBuyButton }) => {
   const { showButtonOnHover, ...rest } = defaultSchema.properties
   return {
     ...defaultSchema,
-    properties: Object.assign(rest, hideBuyButton ? {} : { showButtonOnHover }),
+    properties: {
+      ...rest,
+      ...(hideBuyButton ? {} : { showButtonOnHover }),
+    },
   }
 }
 

--- a/react/__tests__/Price.test.js
+++ b/react/__tests__/Price.test.js
@@ -15,15 +15,21 @@ describe('<Price /> component', () => {
   const defaultConfiguration = {}
 
   function renderComponent(customProps, intlInfo = getIntlContextInfo()) {
-    const props = Object.assign({}, productPropsMock, defaultConfiguration, customProps)
+    const props = Object.assign(
+      {},
+      productPropsMock,
+      defaultConfiguration,
+      customProps
+    )
     const { context, childContextTypes, locale } = intlInfo
 
     const intl = getIntlInstance({ locale }, context)
     loadTranslation(`../locales/${locale}.json`)
 
-    const component = mountWithIntl(
-      <Price {...props} />, { context, childContextTypes }
-    )
+    const component = mountWithIntl(<Price {...props} />, {
+      context,
+      childContextTypes,
+    })
 
     return {
       component,
@@ -47,14 +53,22 @@ describe('<Price /> component', () => {
   })
 
   it('should not show the list price if prop showListPrice is false', () => {
-    const { component, context, intl } = renderComponent({ showListPrice: false })
+    const { component, context, intl } = renderComponent({
+      showListPrice: false,
+    })
 
     const currencyOptions = getCurrencyOptions(context)
     const listPriceLabel = intl.formatMessage({ id: 'pricing.from' })
-    const listPrice = intl.formatNumber(productPropsMock.listPrice, currencyOptions)
+    const listPrice = intl.formatNumber(
+      productPropsMock.listPrice,
+      currencyOptions
+    )
 
     const sellingPriceLabel = intl.formatMessage({ id: 'pricing.to' })
-    const sellingPrice = intl.formatNumber(productPropsMock.sellingPrice, currencyOptions)
+    const sellingPrice = intl.formatNumber(
+      productPropsMock.sellingPrice,
+      currencyOptions
+    )
 
     expect(component.contains(listPriceLabel)).toBe(false)
     expect(component.contains(listPrice)).toBe(false)
@@ -67,7 +81,10 @@ describe('<Price /> component', () => {
       const { component, context, intl } = renderComponent()
 
       const currencyOptions = getCurrencyOptions(context)
-      const listPrice = intl.formatNumber(productPropsMock.listPrice, currencyOptions)
+      const listPrice = intl.formatNumber(
+        productPropsMock.listPrice,
+        currencyOptions
+      )
 
       expect(component.contains(listPrice)).toBe(true)
     })
@@ -86,11 +103,18 @@ describe('<Price /> component', () => {
       const { component, context, intl } = renderComponent()
 
       const currencyOptions = getCurrencyOptions(context)
-      const formattedInstallmentPrice = intl.formatNumber(productPropsMock.installmentPrice, currencyOptions)
-      const formattedMessage = intl.formatMessage({ id: 'pricing.installment-display' }, {
-        installments: productPropsMock.installments,
-        installmentPrice: formattedInstallmentPrice,
-      })
+      const formattedInstallmentPrice = intl.formatNumber(
+        productPropsMock.installmentPrice,
+        currencyOptions
+      )
+      const formattedMessage = intl.formatMessage(
+        { id: 'pricing.installment-display' },
+        {
+          installments: productPropsMock.installments,
+          installmentPrice: formattedInstallmentPrice,
+          times: <span>&times;</span>,
+        }
+      )
 
       expect(component.contains(formattedMessage)).toBe(false)
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add some logic to the Summary schema to hide unnecessary properties.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The property `showButtonOnHover` is unnecessary if `hideBuyButton` is activated.

#### How should this be manually tested?
[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/39262918-308fb5ca-4897-11e8-9d32-e118afe2b214.png)
![image](https://user-images.githubusercontent.com/15948386/39262931-36759022-4897-11e8-94e3-adba21013b26.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
