### PR TITLE
Improve layout and fixed button's and name's heights

### DIFF
--- a/react/Price.js
+++ b/react/Price.js
@@ -38,7 +38,7 @@ class Price extends Component {
     return (
       <div className="vtex-price tc fabriga">
         {showListPrice && (
-          <div className="pv1 f7 normal">
+          <div className="pv1 f6 normal">
             {showLabels && (
               <div className="vtex-price-list__label dib">
                 <FormattedMessage id="pricing.from" />
@@ -49,7 +49,7 @@ class Price extends Component {
             </div>
           </div>
         )}
-        <div className="pv1 b f5">
+        <div className="pv1 b f4">
           {showLabels && (
             <div className="vtex-price-selling__label dib">
               <FormattedMessage id="pricing.to" />

--- a/react/ProductName.js
+++ b/react/ProductName.js
@@ -10,10 +10,10 @@ class ProductName extends Component {
 
     return (
       <div className="vtex-product-name overflow-hidden">
-        <div className="f5 truncate">
+        <div className="f5">
           {name} {brandName && `(${brandName})`}
         </div>
-        <div className="f6 truncate">{skuName}</div>
+        <div className="f6">{skuName}</div>
       </div>
     )
   }

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -54,51 +54,52 @@ class ProductSummary extends Component {
 
     return (
       <div
-        className="vtex-product-summary tc pointer pa3 overflow-hidden"
+        className="vtex-product-summary tc pointer pa3 overflow-hidden center br3 h-100 flex flex-column justify-between"
         onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}>
+        onMouseLeave={this.handleMouseLeave}
+        onClick={this.handleClick}>
         <div>
-          <div onClick={this.handleClick}>
-            <div>
-              {showBadge ? (
-                <DiscountBadge
-                  listPrice={product.listPrice}
-                  sellingPrice={product.sellingPrice}
-                  label={badgeText}>
-                  <img
-                    className="vtex-product-summary__image"
-                    alt={product.name}
-                    src={product.imageUrl}
-                  />
-                </DiscountBadge>
-              ) : (
+          <div>
+            {showBadge ? (
+              <DiscountBadge
+                listPrice={product.listPrice}
+                sellingPrice={product.sellingPrice}
+                label={badgeText}>
                 <img
                   className="vtex-product-summary__image"
                   alt={product.name}
                   src={product.imageUrl}
                 />
-              )}
-            </div>
-            <div className="vtex-product-summary__name-container pv5 near-black">
-              <ProductName
-                name={product.name}
-                skuName={product.skuName}
-                brandName={product.brandName}
+              </DiscountBadge>
+            ) : (
+              <img
+                className="vtex-product-summary__image"
+                alt={product.name}
+                src={product.imageUrl}
               />
-            </div>
-            <div className="vtex-price-container pv1">
-              <Price
-                listPrice={product.listPrice}
-                sellingPrice={product.sellingPrice}
-                installments={product.installments}
-                installmentPrice={product.installmentPrice}
-                showListPrice={showListPrice}
-                showLabels={showLabels}
-                showInstallments={showInstallments}
-              />
-            </div>
+            )}
           </div>
-          <div className="pv2">
+          <div className="vtex-product-summary__name-container pv5 near-black">
+            <ProductName
+              name={product.name}
+              skuName={product.skuName}
+              brandName={product.brandName}
+            />
+          </div>
+        </div>
+        <div>
+          <div className="vtex-price-container pv1">
+            <Price
+              listPrice={product.listPrice}
+              sellingPrice={product.sellingPrice}
+              installments={product.installments}
+              installmentPrice={product.installmentPrice}
+              showListPrice={showListPrice}
+              showLabels={showLabels}
+              showInstallments={showInstallments}
+            />
+          </div>
+          <div className="pv5">
             <div>
               {!hideBuyButton &&
                 (!showButtonOnHover || this.state.isHovering) && (

--- a/react/index.js
+++ b/react/index.js
@@ -13,7 +13,7 @@ const props = {
 export default class GettingStartedIndex extends Component {
   render() {
     return (
-      <div className="pv5 flex">
+      <div className="pv5 flex justify-center">
         <div className="ph4">
           <ExtensionPoint id="product-summary" {...props} />
         </div>

--- a/react/summary.css
+++ b/react/summary.css
@@ -5,18 +5,18 @@
 
 :global .vtex-product-summary {
   width: 281px;
-  height: 380px;
   -webkit-transition: box-shadow 0.25s; /* Safari */
   transition: box-shadow 0.25s;
 }
 
 :global .vtex-product-summary:hover {
-  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 4px 8px 0 rgba(0, 0, 0, 0.2);
 }
 
 :global .vtex-product-summary__image {
   max-width: 176px;
   max-height: 176.3px;
+  margin: auto;
 }
 
 :global .vtex-product-summary button {


### PR DESCRIPTION
This pull requests improves the layout of Product Summary and equals the heights of the elements on a shelf using flexbox.

<img width="1001" alt="screen shot 2018-04-27 at 1 11 53 am" src="https://user-images.githubusercontent.com/21203990/39344313-106b4db4-49b8-11e8-90b7-6a946d519294.png">
