### PR TITLE
 Fix Link component params to use linkText in a prop slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,32 +7,37 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2018-05-08
+## Fixed 
+- Fix Link component params to use linkText in a prop slug
+
 ## [0.3.0] - 2018-05-07
 ### Added
-* Add the Product Image component which is responsible to display a main image and a list of thumbnail images of a Product.
+- Add the Product Image component which is responsible to display a main image and a list of thumbnail images of a Product.
 
 ### Changed
-* Use the _Link_ Component from _render_ module.
-* Use _Price_, _ProductName_ and _DiscountBadge_ from [npm-storecomponents](https://github.com/vtex-apps/npm-storecomponents).
+- Use the _Link_ Component from _render_ module.
+- Use _Price_, _ProductName_ and _DiscountBadge_ from [npm-storecomponents](https://github.com/vtex-apps/npm-storecomponents).
 
 ### Fixed
-* Fix components style that was overwritten by the _Link_ Component.
+- Fix components style that was overwritten by the _Link_ Component.
 
 ### Removed
-* Removed _ProductImage_ Component and it's dependencies.
+- Removed _ProductImage_ Component and it's dependencies.
 
 ## [0.2.1] - 2018-04-27
 ### Fixed
-* Fix summary style on mobile screens with the shelf component
+- Fix summary style on mobile screens with the shelf component
 
 ## [0.2.0] - 2018-04-26
 ### Added
-* Add the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
+- Add the component dynamic schema props to hide the `showButtonOnHover` property if `hideBuyButton` is activated.
+
 ### Fixed
-* Does not show list price when it is equal to selling price
-* Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
+- Does not show list price when it is equal to selling price
+- Always shows the buy button on mobile if `showButtonOnHover` is activated (smartphones and tablets)
 * Add default schema props to the _Product Summary_
 
 ## [0.1.0] - 2018-04-24
 ### Added
-* **Component** Create the VTEX Store Component _Product Summary_
+- **Component** Create the VTEX Store Component _Product Summary_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.1] - 2018-05-08
 ## Fixed 
-- Fix Link component params to use linkText in a prop slug
+- Fix Link component params to use `linkText` in a prop slug
 
 ## [0.3.0] - 2018-05-07
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,7 +1,7 @@
 {
   "pages": {
     "product-summary": {
-      "path": "/product-summary",
+      "path": "/_v/product-summary",
       "extensible": true
     }
   },

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -117,8 +117,8 @@ class ProductSummary extends Component {
 ProductSummary.propTypes = {
   /** Product that owns the informations */
   product: PropTypes.shape({
-    /** Product's id */
-    productId: PropTypes.string.isRequired,
+    /** Product's link text */
+    linkText: PropTypes.string.isRequired,
     /** Product's name */
     productName: PropTypes.string.isRequired,
     /** Product's brand */

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -51,7 +51,7 @@ class ProductSummary extends Component {
         <Link
           className="clear-link"
           page={'store/product'}
-          params={{ id: product.productId }}>
+          params={{ id: product.linkText }}>
           <div className="pointer pa3">
             <div className="vtex-product-summary__image-container center db">
               {showBadge ? (

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -51,7 +51,7 @@ class ProductSummary extends Component {
         <Link
           className="clear-link"
           page={'store/product'}
-          params={{ id: product.linkText }}>
+          params={{ slug: product.linkText }}>
           <div className="pointer pa3">
             <div className="vtex-product-summary__image-container center db">
               {showBadge ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
 Fix params of Link component to use `product.linkText` in a prop slug. This will fix a redirect issue on the dreamstore project. 

#### Screenshots or example usage
Click on a product card, will redirect to ProductPage
https://dreamstore--storecomponents.myvtexdev.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
