### PR TITLE
Add vtex.storecomponents as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.1] - 2018-05-09
+### Changed
+- Change dependencies to use the buy button being provided by `vtex.storecomponents` app instead of npm module.
+### Fixed
+- Move buy button to outside of product page link
+
 ## [0.4.0] - 2018-05-09
 ### Changed 
 - Update productSummary to get `skuId`, and pass through `BuyButton` component.

--- a/manifest.json
+++ b/manifest.json
@@ -23,5 +23,8 @@
     "termsURL": "http://route.to.the/terms",
     "version": "0.1",
     "free": true
+  },
+  "dependencies": {
+    "vtex.storecomponents": "0.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl'
 import { isMobile } from 'react-device-detect'
 import { Link } from 'render'
 
-import BuyButton from '@vtex/buy-button'
+import BuyButton from 'vtex.storecomponents/BuyButton'
 import { DiscountBadge, ProductName, Price } from '@vtex/product-details'
 
 import { createProduct } from './ProductFactory'

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -46,8 +46,8 @@ class ProductSummary extends Component {
         className="vtex-product-summary tc overflow-hidden center br3 flex flex-column justify-between"
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}>
-          <div className="pointer pa3">
-            <Link
+        <div className="pointer pa3">
+          <Link
             className="clear-link"
             page={'store/product'}
             params={{ slug: product.linkText }}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change dependencies to use the buy button being provided by `vtex.storecomponents` app instead of npm module.

#### Screenshots or example usage
https://dreamstore--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
