### PR TITLE
Remove afterClick param of BuyButton call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.4.1] - 2018-05-09
+## [0.4.2] - 2018-05-11
+### Changed
+- Remove `afterClick` param of BuyButton call.
+
+## [0.4.1] - 2018-05-10
 ### Changed
 - Change dependencies to use the buy button being provided by `vtex.storecomponents` app instead of npm module.
 ### Fixed

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -64,12 +64,12 @@ class ProductSummary extends Component {
                   />
                 </DiscountBadge>
               ) : (
-                <img
-                  className="vtex-product-summary__image"
-                  alt={product.productName}
-                  src={product.sku.image.imageUrl}
-                />
-              )}
+                  <img
+                    className="vtex-product-summary__image"
+                    alt={product.productName}
+                    src={product.sku.image.imageUrl}
+                  />
+                )}
             </div>
             <div className="vtex-product-summary__name-container flex items-center justify-center near-black">
               <ProductName
@@ -95,14 +95,13 @@ class ProductSummary extends Component {
           <div className="vtex-product-summary__buy-button-container pv2">
             {!hideBuyButton &&
               (!showButtonOnHover || this.state.isHovering) && (
-              <div className="vtex-product-summary__buy-button center">
-                <BuyButton
-                  skuId={product.sku.itemId}
-                  afterClick={() => console.log('Ok foi adicionado')}>
-                  {buyButtonText || <FormattedMessage id="button-label" />}
-                </BuyButton>
-              </div>
-            )}
+                <div className="vtex-product-summary__buy-button center">
+                  <BuyButton
+                    skuId={product.sku.itemId}>
+                    {buyButtonText || <FormattedMessage id="button-label" />}
+                  </BuyButton>
+                </div>
+              )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make product summary use properly the buy button app. 

#### What problem is this solving?
Buy Button don't need to receive an  `afterClick` param. [See BuyButton PR](https://github.com/vtex-apps/npm-storecomponents/pull/27)

#### Screenshots or example usage
https://dev--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
