### PR TITLE
Add isOneClickBuy attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Changed component added isOneClickBuy attribute.
+### Added
+- Added isOneClickBuy attribute.
 
 ## [0.5.1] - 2018-05-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed component added isOneClickBuy attribute.
 
 ## [0.5.1] - 2018-05-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Product summary is a canonical component that any VTEX store can install.
 ### Travis CI 
 [![Build Status](https://travis-ci.org/vtex-apps/product-summary.svg?branch=master)](https://travis-ci.org/vtex-apps/product-summary)
 
-## Usage
-
-TODO
-
 ### Running Tests
 
 To run the test suit, type the following in the terminal, inside the folder `react`
@@ -26,15 +22,19 @@ To update the tests snapshots use
 $ npm t -- -u  # like this
 $ yarn test -u # or this
 ```
-
-## Configuration
-
-TODO
-
 ## Troubleshooting
 
 You can check if others are experiencing similar issues [here](https://github.com/vtex-apps/product-summary/issues). Also feel free to [open issues](https://github.com/vtex-apps/product-summary/issues/new).
 
-## Contributing
-
-TODO
+| Prop name          | Type       | Description                                                                 |
+| ------------------ | ---------- | --------------------------------------------------------------------------- |
+| `product`          | `Product`  | Product that owns the informations                                          |
+| `showListPrice`    | `Boolean`  | Shows the product list price                                                |
+| `isOneClickBuy`    | `Boolean`  | Should redirect to checkout after clicking on buy                           |
+| `showLabels`       | `Boolean`  | Set pricing labels' visibility                                              |
+| `showInstallments` | `Boolean`  | Set installments' visibility                                                |
+| `showBadge`        | `Boolean`  | Set the discount badge's visibility                                         |
+| `badgeText`        | `String`   | Text shown on badge                                                         |
+| `buyButtonText`    | `String`   | Custom buy button text                                                      |
+| `hideBuyButton`    | `Boolean`  | Hides the buybutton completely                                              |
+| `showButtonOnHover`| `Boolean`  | Defines if the button is shown only if the mouse is on the summary          |

--- a/README.md
+++ b/README.md
@@ -38,3 +38,50 @@ You can check if others are experiencing similar issues [here](https://github.co
 | `buyButtonText`    | `String`   | Custom buy button text                                                      |
 | `hideBuyButton`    | `Boolean`  | Hides the buybutton completely                                              |
 | `showButtonOnHover`| `Boolean`  | Defines if the button is shown only if the mouse is on the summary          |
+
+
+Product: 
+
+| Prop name          | Type       | Description                                                                 |
+| ------------------ | ---------- | --------------------------------------------------------------------------- |
+| `linkText`         | `String!`  | Product's link text                                                         |
+| `productName`      | `String!`  | Product's name                                                              |
+| `brand`            | `String!`  | Product's brand                                                             |
+| `sku`              | `SKU`      | Product's SKU                                                               |
+| `buyButtonText`    | `String`   | Custom buy button text                                                      |
+| `hideBuyButton`    | `Boolean`  | Hides the buybutton completely                                              |
+| `showButtonOnHover`| `Boolean`  | Defines if the button is shown only if the mouse is on the summary          |
+
+Sku:
+
+| Prop name          | Type       | Description                                                                 |
+| ------------------ | ---------- | --------------------------------------------------------------------------- |
+| `name`             | `String!`  | SKU name                                                                    |
+| `itemId`           | `String!`  | SKU id                                                                      |
+| `image`            | `Image`    | SKU Image to be shown                                                       |
+| `seller`           | `Seller`   | SKU seller                                                                  |
+
+Image:
+
+| Prop name          | Type       | Description                                                                 |
+| ------------------ | ---------- | --------------------------------------------------------------------------- |
+| `imageUrl`         | `String!`  | Image URL                                                                   |
+| `imageTag`         | `String!`  | Image tag as string                                                         |
+
+Seller:
+
+| Prop name                     | Type                 | Description                                            |
+| ----------------------------- | -------------------- | ------------------------------------------------------ |
+| `commertialOffer`             | `CommertialOffer`    | Seller comertial offer                                 |
+| `commertialOffer.Installments`| `Array(Installment)` | Selling Price                                          |
+| `commertialOffer.Price`       | `Number`             | List Price                                             |
+
+Instalment:
+
+| Prop name                        | Type       | Description                                                   |
+| -------------------------------- | ---------- | ------------------------------------------------------------- |
+| `Value`                          | `Number!`  | Installment value                                             |
+| `InterestRate`                   | `Number!`  | Interest rate (zero if interest-free)                         |
+| `TotalValuePlusInterestRate`     | `Number`   | Calculated total value                                        |
+| `NumberOfInstallments`           | `Number!`  | Number of installments                                        |
+| `Name`                           | `String`   | Installments offer name                                       |

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -108,7 +108,7 @@ class ProductSummary extends Component {
             {!hideBuyButton &&
               (!showButtonOnHover || this.state.isHovering) && (
                 <div className="vtex-product-summary__buy-button center">
-                  <BuyButton skuId={product.sku.itemId} isOneClickBuy>
+                  <BuyButton skuId={product.sku.itemId} isOneClickBuy={isOneClickBuy}>
                     {buyButtonText || <FormattedMessage id="button-label" />}
                   </BuyButton>
                 </div>

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -26,6 +26,7 @@ class ProductSummary extends Component {
     showBadge: true,
     hideBuyButton: false,
     showOnHover: false,
+    isOneClickBuy: false,
   }
 
   constructor(props) {
@@ -50,6 +51,7 @@ class ProductSummary extends Component {
       badgeText,
       buyButtonText,
       hideBuyButton,
+      isOneClickBuy,
     } = this.props
 
     const product = this.props.product || createProduct()
@@ -77,12 +79,12 @@ class ProductSummary extends Component {
                   />
                 </DiscountBadge>
               ) : (
-                <img
-                  className="vtex-product-summary__image"
-                  alt={product.productName}
-                  src={product.sku.image.imageUrl}
-                />
-              )}
+                  <img
+                    className="vtex-product-summary__image"
+                    alt={product.productName}
+                    src={product.sku.image.imageUrl}
+                  />
+                )}
             </div>
             <div className="vtex-product-summary__name-container flex items-center justify-center near-black">
               <ProductName
@@ -106,7 +108,7 @@ class ProductSummary extends Component {
             {!hideBuyButton &&
               (!showButtonOnHover || this.state.isHovering) && (
                 <div className="vtex-product-summary__buy-button center">
-                  <BuyButton skuId={product.sku.itemId}>
+                  <BuyButton skuId={product.sku.itemId} isOneClickBuy>
                     {buyButtonText || <FormattedMessage id="button-label" />}
                   </BuyButton>
                 </div>
@@ -127,6 +129,11 @@ const defaultSchema = {
       type: 'boolean',
       title: "Show product's list price",
       default: true,
+    },
+    isOneClickBuy: {
+      type: 'boolean',
+      title: "Should redirect to checkout after clicking on buy",
+      default: false,
     },
     showLabels: {
       type: 'boolean',

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -51,6 +51,8 @@ export default {
   }),
   /** Shows the product list price */
   showListPrice: PropTypes.bool,
+  /** Should redirect to checkout after clicking on buy */
+  isOneClickBuy: PropTypes.bool,
   /** Set pricing labels' visibility */
   showLabels: PropTypes.bool,
   /** Set installments' visibility */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add isOneClickBuy attribute to the BuyComponent 

**BuyButton**: https://github.com/vtex-apps/store-components/pull/73

#### What problem is this solving?
BuyButton has the option of redirecting the user straight to checkout after being clicked.

#### How should this be manually tested?
[workspace](https://oneclickbuy--storecomponents.myvtex.com/)

#### Linked to:
[- PR 73](https://github.com/vtex-apps/store-components/pull/73)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
