### PR TITLE
Add content loader into the Product Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Content loader into the `ProductSummary`
 
 ## [0.6.0] - 2018-6-11
 ### Added

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -11,6 +11,8 @@ import DiscountBadge from 'vtex.store-components/DiscountBadge'
 import { createProduct } from './ProductFactory'
 import ProductSummaryPropTypes from './propTypes'
 
+import ContentLoader from 'react-content-loader'
+
 import './global.css'
 
 /**
@@ -27,6 +29,7 @@ class ProductSummary extends Component {
     hideBuyButton: false,
     showOnHover: false,
     isOneClickBuy: false,
+    isLoading: true,
   }
 
   constructor(props) {
@@ -52,6 +55,7 @@ class ProductSummary extends Component {
       buyButtonText,
       hideBuyButton,
       isOneClickBuy,
+      isLoading,
     } = this.props
 
     const product = this.props.product || createProduct()
@@ -67,18 +71,25 @@ class ProductSummary extends Component {
             page={'store/product'}
             params={{ slug: product.linkText }}>
             <div className="vtex-product-summary__image-container center db">
-              {showBadge ? (
-                <DiscountBadge
-                  listPrice={product.sku.seller.commertialOffer.ListPrice}
-                  sellingPrice={product.sku.seller.commertialOffer.Price}
-                  label={badgeText}>
-                  <img
-                    className="vtex-product-summary__image"
-                    alt={product.productName}
-                    src={product.sku.image.imageUrl}
-                  />
-                </DiscountBadge>
-              ) : (
+              {isLoading ? (
+                <div>
+                  <ContentLoader height={500} speed={1}>
+                    <rect x="0" y="0" rx="5" ry="5" width="370" height="370" />
+                  </ContentLoader>
+                </div>
+              )
+                : showBadge ? (
+                  <DiscountBadge
+                    listPrice={product.sku.seller.commertialOffer.ListPrice}
+                    sellingPrice={product.sku.seller.commertialOffer.Price}
+                    label={badgeText} >
+                    <img
+                      className="vtex-product-summary__image"
+                      alt={product.productName}
+                      src={product.sku.image.imageUrl}
+                    />
+                  </DiscountBadge>
+                ) : (
                   <img
                     className="vtex-product-summary__image"
                     alt={product.productName}
@@ -91,6 +102,7 @@ class ProductSummary extends Component {
                 name={product.productName}
                 skuName={product.sku.name}
                 brandName={product.brand}
+                isLoading={isLoading}
               />
             </div>
             <div className="vtex-price-container flex flex-column justify-center items-center pv2">
@@ -101,18 +113,22 @@ class ProductSummary extends Component {
                 showListPrice={showListPrice}
                 showLabels={showLabels}
                 showInstallments={showInstallments}
+                isLoading={isLoading}
               />
             </div>
           </Link>
           <div className="vtex-product-summary__buy-button-container pv2">
             {!hideBuyButton &&
               (!showButtonOnHover || this.state.isHovering) && (
-                <div className="vtex-product-summary__buy-button center">
-                  <BuyButton skuId={product.sku.itemId} isOneClickBuy={isOneClickBuy}>
-                    {buyButtonText || <FormattedMessage id="button-label" />}
-                  </BuyButton>
-                </div>
-              )}
+              <div className="vtex-product-summary__buy-button center">
+                <BuyButton
+                  skuId={product.sku.itemId}
+                  isOneClickBuy={isOneClickBuy}
+                  isLoading={isLoading}>
+                  {buyButtonText || <FormattedMessage id="button-label" />}
+                </BuyButton>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -132,7 +148,7 @@ const defaultSchema = {
     },
     isOneClickBuy: {
       type: 'boolean',
-      title: "Should redirect to checkout after clicking on buy",
+      title: 'Should redirect to checkout after clicking on buy',
       default: false,
     },
     showLabels: {

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "vtex.render-getting-started",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "react-content-loader": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-3.1.2.tgz",
+      "integrity": "sha512-9Fv10F6rrzFDIT04aoRsw3dbN6l6onNXbBvCpt4OjXZFGDz/P65laNIujHVTlVjcqErut9d4BL0aplVByyGcJw=="
+    }
+  }
+}

--- a/react/package.json
+++ b/react/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.5",
+    "react-content-loader": "^3.1.2",
     "react-device-detect": "^1.3.4"
   },
   "devDependencies": {

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -67,4 +67,6 @@ export default {
   hideBuyButton: PropTypes.bool,
   /** Defines if the button is shown only if the mouse is on the summary */
   showButtonOnHover: PropTypes.bool,
+  /** Flag that indicates if is loading */
+  isLoading: PropTypes.bool,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add content loader into the Product Summary.

#### What problem is this solving?
This component did not have it.

#### How should this be manually tested?
https://waza2--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
