### PR TITLE
Fix breaking error on undefined productClusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop to set whether or not to show the collection badges.
+
+### Fixed
+- Error when `productClusters` were `undefined`.
 
 ## [0.8.0] - 2018-6-20
 ### Added

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -25,6 +25,7 @@ class ProductSummary extends Component {
     showInstallments: true,
     showLabels: true,
     showBadge: true,
+    showCollections: true,
     hideBuyButton: false,
     showOnHover: false,
     isOneClickBuy: false,
@@ -48,6 +49,7 @@ class ProductSummary extends Component {
       product,
       showBadge,
       badgeText,
+      showCollections,
     } = this.props
     const { productClusters, productName: name, sku: { image: { imageUrl } } } = product
 
@@ -65,7 +67,7 @@ class ProductSummary extends Component {
       )
     }
 
-    if (productClusters.length > 0) {
+    if (showCollections && productClusters && productClusters.length > 0) {
       const collections = productClusters.map(cl => cl.name)
 
       return (

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -71,4 +71,6 @@ export default {
   hideBuyButton: PropTypes.bool,
   /** Defines if the button is shown only if the mouse is on the summary */
   showButtonOnHover: PropTypes.bool,
+  /** Defines if the collection badges are shown */
+  showCollections: PropTypes.bool,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add check for the value on the `productClusters` prop before checking it's length and added prop to set whether or not to show the collection badges.

#### What problem is this solving?
The component was breaking when the `productClusters` were `undefined` and there was no way to hide the collection badges before.

#### How should this be manually tested?
[Access this workspace](https://maxitemsimage--storecomponents.myvtex.com/samsung-s9/p).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
