### PR TITLE
Fix buy button passed props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `BuyButton` passed props.
 
 ## [0.8.2] - 2018-7-9
 ### Added

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -129,7 +129,15 @@ class ProductSummary extends Component {
               (!showButtonOnHover || this.state.isHovering) && (
                 <div className="vtex-product-summary__buy-button center">
                   <BuyButton
-                    skuId={product.sku.itemId}
+                    skuItems={
+                      [ 
+                        {
+                          skuId: product.sku.itemId,
+                          quantity: 1,
+                          seller: 1,
+                        },
+                      ]
+                    }
                     isOneClickBuy={isOneClickBuy}>
                     {buyButtonText || <FormattedMessage id="button-label" />}
                   </BuyButton>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix buy button passed props.

#### What problem is this solving?
The BuyButton props has changed and being not updated into the ProductSummary component.

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/">Workspace</a>

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
