### PR TITLE
Fix Content Loader on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Content loader to work on Firefox.
 
 ## [0.8.5] - 2018-08-08
 ### Added

--- a/react/ProductSummary.js
+++ b/react/ProductSummary.js
@@ -87,14 +87,13 @@ class ProductSummary extends Component {
 
   renderImageLoader = () => (
     <ContentLoader
-      uniquekey="vtex-summary-image-loader"
       style={{
         width: '100%',
         height: '100%',
       }}
       height="100%"
       width="100%">
-      <rect className="vtex-product-summary__image-loader" />
+      <rect width="100%" height="100%" />
     </ContentLoader>
   )
 

--- a/react/summary.css
+++ b/react/summary.css
@@ -43,11 +43,6 @@
   height: 5em;
 }
 
-.vtex-product-summary__image-loader {
-  width: 100%;
-  height: 100%;
-}
-
 a.clear-link {
   text-decoration: inherit;
   color: inherit;


### PR DESCRIPTION
#### What is the purpose of this pull request?
On Firefox, it was not possible to determine the SVG's style via CSS/Style prop. So, what works on Chrome and Safari, doesn't work on Firefox. To work in all browsers, the found solution was pass every style via elements properties.

#### What problem is this solving?
Content Loaders not rendering on Firefox.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/44040764-70ba6314-9ef2-11e8-8730-1ba7e0225ec0.png)



#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
