### PR TITLE
Use the SKU sellerId in BuyButton instead of set the seller in a hard code way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Fixed
 - Added sellerId in `BuyButton` component.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] - 2018-10-25
+### Fixed
+- Added sellerId in `BuyButton` component.
+
 ## [1.4.0] - 2018-10-02
 ### Added
 - New display modes of the summary (small and inline).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.5.0] - 2018-10-25
 ### Fixed
 - Added sellerId in `BuyButton` component.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.1] - 2018-10-25
 ### Fixed
 - Added sellerId in `BuyButton` component.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -256,7 +256,7 @@ class ProductSummary extends Component {
                         {
                           skuId: path(['sku', 'itemId'], product),
                           quantity: 1,
-                          seller: 1,
+                          seller: path(['sku', 'seller', 'sellerId'], product),
                         },
                       ]
                     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Change the default `seller` props in `BuyButton` to a value taken from product/sku.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Pass as BuyButton's props the sellerId taken from query.

#### How should this be manually tested?
https://arthur--storecomponents.myvtex.com

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
