### PR TITLE
Fix SVG warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix svg warning caused by the `ContentLoader`.
 
 ## [1.6.1] - 2018-11-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.2] - 2018-11-27
 ### Fixed
 - Fix svg warning caused by the `ContentLoader`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -147,6 +147,7 @@ class ProductSummary extends Component {
       }}
       width={100}
       height={56}
+      preserveAspectRatio="xMinYMin meet"
     >
       <rect width="100%" height="100%" />
     </ContentLoader>

--- a/react/index.js
+++ b/react/index.js
@@ -145,8 +145,8 @@ class ProductSummary extends Component {
         width: '100%',
         height: '100%',
       }}
-      height="100%"
-      width="100%"
+      width="100"
+      height="56"
     >
       <rect width="100%" height="100%" />
     </ContentLoader>

--- a/react/index.js
+++ b/react/index.js
@@ -145,8 +145,8 @@ class ProductSummary extends Component {
         width: '100%',
         height: '100%',
       }}
-      width="100"
-      height="56"
+      width={100}
+      height={56}
     >
       <rect width="100%" height="100%" />
     </ContentLoader>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Replace the unit in which the width and height of content loaders were defined.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The height and width props of the react-content-loader were being defined using percentage but as these values are used to define the viewBox of the content loader warnings were shown. This PR replace these percentage values with user units, adequate to each content loader.

#### How should this be manually tested?
[Access this workspace](https://svgerrorpd--storecomponents.myvtex.com/iphone-xs/p), open the console. Select slow 3g in the network tab so you can see the content loaders.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
