### PR TITLE
Fix buy button dont showing on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Buy button dont showing on hover's action when this option has active on frontstore.
 
 ## [1.5.0] - 2018-11-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.1] - 2018-11-26
 ### Fixed
 - Buy button not showing on hover's action when this option is active on frontstore.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Buy button dont showing on hover's action when this option has active on frontstore.
+- Buy button not showing on hover's action when this option is active on frontstore.
 
 ## [1.5.0] - 2018-11-07
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -250,7 +250,7 @@ class ProductSummary extends Component {
             </div>
           </Link>
           <div className={buyButtonClasses}>
-            {showButtonOnHover || showBuyButton && (
+            {(showButtonOnHover || showBuyButton) && (
               <div className="vtex-product-summary__buy-button center mw-100">
                 {showBuyButton &&
                   <BuyButton


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix buy button dont showing on hover
Closes https://github.com/vtex-apps/shelf/issues/80

#### What problem is this solving?
Buy button not showing on hover's action when this option is active on frontstore.

#### How should this be manually tested?
[Access this workspace](https://fixbuybutton--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
