### PR TITLE
Use product image according to client device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use different image sizes in mobile and desktop.
 
 ## [2.1.0] - 2018-12-06
 ### Fixed

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -1,15 +1,36 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 /** Image component with 1:1 aspect ratio */
-export default function Image({ src, className }) {
-  return (
-    <div
-      className={classNames(className, 'vtex-aspect-ratio w-100')}
-      style={{ backgroundImage: `url(${src})` }}
-    />
-  )
+/** TODO use a generic approach to resize images in Dreamstore */
+class Image extends Component {
+
+  resizeUrl = src => {
+    //Check of src is already in a size defined by the client
+    const isWithMeasures = new RegExp(/[1-9]+-(:?([1-9]+)|(auto))/)
+    if (isWithMeasures.exec(src)) {
+      return src
+    }
+
+    const { width } = this.props
+
+    const imageId = src.slice(src.indexOf('/ids/')).split('/')[2]
+    const withSuffix = `${imageId}-${width}-auto`
+
+    return src.replace(imageId, withSuffix)
+  }
+
+  render() {
+    const { src, className } = this.props
+
+    return (
+      <div
+        className={classNames(className, 'vtex-aspect-ratio w-100')}
+        style={{ backgroundImage: `url(${this.resizeUrl(src)})` }}
+      />
+    )
+  }
 }
 
 Image.propTypes = {
@@ -17,4 +38,8 @@ Image.propTypes = {
   src: PropTypes.string.isRequired,
   /** Custom classes */
   className: PropTypes.string,
+  /** Image width */
+  width: PropTypes.number
 }
+
+export default Image

--- a/react/index.js
+++ b/react/index.js
@@ -101,7 +101,9 @@ class ProductSummary extends Component {
   }
 
   get renderImage() {
-    const { product, showBadge, badgeText, showCollections } = this.props
+    const WIDTH_MOBILE = 350
+    const WIDTH_DESKTOP = 600
+    const { product, showBadge, badgeText, showCollections, runtime: { hints: { mobile } } } = this.props
     const {
       productClusters,
       productName: name,
@@ -111,7 +113,7 @@ class ProductSummary extends Component {
     } = product
 
     let img = (
-      <Image className="vtex-product-summary__image" alt={name} src={imageUrl} />
+      <Image className="vtex-product-summary__image" width={mobile ? WIDTH_MOBILE : WIDTH_DESKTOP} alt={name} src={imageUrl} />
     )
 
     if (showBadge) {
@@ -254,15 +256,15 @@ class ProductSummary extends Component {
         'dn db-ns': displayMode === 'normal',
       }
     )
-    
-    const showBuyButton =  !showButtonOnHover || mobile || this.state.isHovering
+
+    const showBuyButton = !showButtonOnHover || mobile || this.state.isHovering
     const quantity = path(['sku', 'seller', 'commertialOffer', 'AvailableQuantity'], product) || 0
     const isAvailable = (quantity > 0)
 
     return (
       !hideBuyButton && (
-        <div className={ buyButtonClasses }>
-          <div className={`vtex-product-summary__buy-button center mw-100 ${ !showBuyButton && 'is-hidden' }`}>
+        <div className={buyButtonClasses}>
+          <div className={`vtex-product-summary__buy-button center mw-100 ${!showBuyButton && 'is-hidden'}`}>
             <BuyButton
               available={isAvailable}
               skuItems={
@@ -282,7 +284,7 @@ class ProductSummary extends Component {
         </div>
       )
     )
-    
+
   }
 
 
@@ -341,7 +343,7 @@ class ProductSummary extends Component {
               {this.renderProductPrice}
             </div>
           </Link>
-          { this.renderBuyButton }
+          {this.renderBuyButton}
         </div>
       </div>
     )

--- a/react/index.js
+++ b/react/index.js
@@ -101,8 +101,8 @@ class ProductSummary extends Component {
   }
 
   get renderImage() {
-    const WIDTH_MOBILE = 350
-    const WIDTH_DESKTOP = 600
+    const WIDTH_MOBILE = 600
+    const WIDTH_DESKTOP = 900
     const { product, showBadge, badgeText, showCollections, runtime: { hints: { mobile } } } = this.props
     const {
       productClusters,

--- a/react/index.js
+++ b/react/index.js
@@ -158,19 +158,18 @@ class ProductSummary extends Component {
   }
 
   get renderProductPrice() {
-
     const {
       showListPrice,
       showLabels,
       showInstallments,
       labelSellingPrice,
       displayMode,
-      showBorders
+      showBorders,
     } = this.props
 
     const containerClasses = classNames('vtex-product-summary__price-container flex flex-column justify-end pv2 ', {
       'justify-center items-center': displayMode !== 'inline',
-      'pv2': !showBorders
+      'pv2': !showBorders,
     })
 
     return (
@@ -203,7 +202,7 @@ class ProductSummary extends Component {
     const {
       displayMode,
       product,
-      name: showFieldsProps
+      name: showFieldsProps,
     } = this.props
 
     const containerClasses = classNames(
@@ -234,11 +233,10 @@ class ProductSummary extends Component {
           {...showFieldsProps}
         />
       </div>
-    );
+    )
   }
 
   get renderBuyButton() {
-
     const {
       product,
       displayMode,
@@ -284,9 +282,7 @@ class ProductSummary extends Component {
         </div>
       )
     )
-
   }
-
 
   render() {
     const {
@@ -313,11 +309,11 @@ class ProductSummary extends Component {
     })
 
     const informationClasses = classNames('vtex-product-summary__informations', {
-      'w-80 pv3 pl3 pr3 h-100': displayMode === 'inline'
+      'w-80 pv3 pl3 pr3 h-100': displayMode === 'inline',
     })
 
     const elementClasses = classNames('pointer pa2 flex flex-column', {
-      'bb b--muted-4 ma2': showBorders
+      'bb b--muted-4 ma2': showBorders,
     })
 
     return (


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Use resized images depending on the client device.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The image that was used had always the same size, it could make its loading slow.

#### How should this be manually tested?
[workspace](https://imagesizing--storecomponents.myvtex.com/)
Check that the product image size is different in mobile and desktop.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
