### PR TITLE
Reformat Buy Button display option on storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add buy button display option on StoreFront
 
 ## [2.1.2] - 2018-12-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - 2018-12-14
 ### Changed
 - Add buy button display option on StoreFront.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Add buy button display option on StoreFront
+- Add buy button display option on StoreFront.
 
 ## [2.1.2] - 2018-12-12
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/DisplayButtonTypes.js
+++ b/react/DisplayButtonTypes.js
@@ -16,11 +16,11 @@ const displayButtonTypes = {
 }
 
 export function getDisplayButtonNames() {
-  return map(opt => opt.name ,values(displayButtonTypes))
+  return map(opt => opt.name, values(displayButtonTypes))
 }
 
 export function getDisplayButtonValues() {
-  return map(opt => opt.value ,values(displayButtonTypes))
+  return map(opt => opt.value, values(displayButtonTypes))
 }
 
 export default displayButtonTypes

--- a/react/DisplayButtonTypes.js
+++ b/react/DisplayButtonTypes.js
@@ -1,0 +1,32 @@
+const displayButtonTypes = {
+  DISPLAY_ALWAYS: {
+    name: 'editor.productSummary.displayBuyButton.option.always',
+    value: 'displayButtonAlways',
+  },
+  DISPLAY_ON_HOVER: {
+    name: 'editor.productSummary.displayBuyButton.option.hover',
+    value: 'displayButtonHover',
+  },
+  DISPLAY_NONE: {
+    name: 'editor.productSummary.displayBuyButton.option.none',
+    value: 'displayButtonNone',
+  },
+}
+
+export function getDisplayButtonNames() {
+  const names = []
+  for (const key in displayButtonTypes) {
+    names.push(displayButtonTypes[key].name)
+  }
+  return names
+}
+
+export function getDisplayButtonValues() {
+  const values = []
+  for (const key in displayButtonTypes) {
+    values.push(displayButtonTypes[key].value)
+  }
+  return values
+}
+
+export default displayButtonTypes

--- a/react/DisplayButtonTypes.js
+++ b/react/DisplayButtonTypes.js
@@ -1,3 +1,5 @@
+import { values, map } from 'ramda'
+
 const displayButtonTypes = {
   DISPLAY_ALWAYS: {
     name: 'editor.productSummary.displayBuyButton.option.always',
@@ -14,19 +16,11 @@ const displayButtonTypes = {
 }
 
 export function getDisplayButtonNames() {
-  const names = []
-  for (const key in displayButtonTypes) {
-    names.push(displayButtonTypes[key].name)
-  }
-  return names
+  return map(opt => opt.name ,values(displayButtonTypes))
 }
 
 export function getDisplayButtonValues() {
-  const values = []
-  for (const key in displayButtonTypes) {
-    values.push(displayButtonTypes[key].value)
-  }
-  return values
+  return map(opt => opt.value ,values(displayButtonTypes))
 }
 
 export default displayButtonTypes

--- a/react/index.js
+++ b/react/index.js
@@ -396,12 +396,11 @@ const defaultSchema = {
 }
 
 ProductSummary.getSchema = ({ displayBuyButton }) => {
-  const { ...rest } = defaultSchema.properties
   const nameSchema = ProductName.schema
   return {
     ...defaultSchema,
     properties: {
-      ...rest,
+      ...defaultSchema.properties,
       ...displayBuyButton,
       name: nameSchema,
     },

--- a/react/index.js
+++ b/react/index.js
@@ -395,13 +395,14 @@ const defaultSchema = {
   },
 }
 
-ProductSummary.getSchema = () => {
+ProductSummary.getSchema = ({ displayBuyButton }) => {
   const { ...rest } = defaultSchema.properties
   const nameSchema = ProductName.schema
   return {
     ...defaultSchema,
     properties: {
       ...rest,
+      ...displayBuyButton,
       name: nameSchema,
     },
   }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -9,6 +9,7 @@
   "editor.productSummary.hideBuyButton.title": "Hides the buy button completely",
   "editor.productSummary.showButtonOnHover.title": "Show the buy button only on hover",
   "editor.productSummary.showCollections.title": "Show the collections badges",
+  "editor.productSummary.displayBuyButton.title": "Buy button display mode",
   "editor.productSummary.displayBuyButton.option.none": "Never show",
   "editor.productSummary.displayBuyButton.option.always": "Always show",
   "editor.productSummary.displayBuyButton.option.hover": "Show on hover"

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -8,5 +8,8 @@
   "editor.productSummary.buyButtonText.title": "Custom buy button's text",
   "editor.productSummary.hideBuyButton.title": "Hides the buy button completely",
   "editor.productSummary.showButtonOnHover.title": "Show the buy button only on hover",
-  "editor.productSummary.showCollections.title": "Show the collections badges"
+  "editor.productSummary.showCollections.title": "Show the collections badges",
+  "editor.productSummary.displayBuyButton.option.none": "Never show",
+  "editor.productSummary.displayBuyButton.option.always": "Always show",
+  "editor.productSummary.displayBuyButton.option.hover": "Show on hover"
 }

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -9,6 +9,7 @@
   "editor.productSummary.hideBuyButton.title": "Oculta el botón comprar por completo",
   "editor.productSummary.showButtonOnHover.title": "Mostrar el botón de comprar solo al pasar el mouse",
   "editor.productSummary.showCollections.title": "Mostrar las insignias de las colecciones",
+  "editor.productSummary.displayBuyButton.title": "Modo de visualización de los botones de compra",
   "editor.productSummary.displayBuyButton.option.none": "Nunca mostrar",
   "editor.productSummary.displayBuyButton.option.always": "Siempre mostrar",
   "editor.productSummary.displayBuyButton.option.hover": "Mostrar al pasar el ratón"

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -8,5 +8,8 @@
   "editor.productSummary.buyButtonText.title": "Texto del botón de compra personalizado",
   "editor.productSummary.hideBuyButton.title": "Oculta el botón comprar por completo",
   "editor.productSummary.showButtonOnHover.title": "Mostrar el botón de comprar solo al pasar el mouse",
-  "editor.productSummary.showCollections.title": "Mostrar las insignias de las colecciones"
+  "editor.productSummary.showCollections.title": "Mostrar las insignias de las colecciones",
+  "editor.productSummary.displayBuyButton.option.none": "Nunca mostrar",
+  "editor.productSummary.displayBuyButton.option.always": "Siempre mostrar",
+  "editor.productSummary.displayBuyButton.option.hover": "Mostrar al pasar el ratón"
 }

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -8,5 +8,9 @@
   "editor.productSummary.buyButtonText.title": "Texto do botão de compra personalizado",
   "editor.productSummary.hideBuyButton.title": "Esconde completamente o botão de compra",
   "editor.productSummary.showButtonOnHover.title": "Mostrar o botão de compra apenas ao passar o mouse",
-  "editor.productSummary.showCollections.title": "Mostrar os selos de coleção"
+  "editor.productSummary.showCollections.title": "Mostrar os selos de coleção",
+  "editor.productSummary.displayBuyButton.title": "Modo de visualização dos botões de compra",
+  "editor.productSummary.displayBuyButton.option.none": "Nunca mostrar",
+  "editor.productSummary.displayBuyButton.option.always": "Sempre mostrar",
+  "editor.productSummary.displayBuyButton.option.hover": "Mostrar ao passar o mouse"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove previous options of buy button and merge it into one

#### What problem is this solving?
Make it less confusing to customize on storefront

#### How should this be manually tested?
[Access this workspace](https://buybutton--storecomponents.myvtex.com/)

#### Screenshots or example usage
![tempsnip](https://user-images.githubusercontent.com/5597778/50002981-c4f3aa00-ff80-11e8-8695-c5419e61a9b7.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
