### PR TITLE
Change price color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed price color.
 
 ## [2.3.0] - 2018-12-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.1] - 2018-12-14
 ### Changed
 - Changed price color.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -189,7 +189,7 @@ class ProductSummary extends Component {
           listPriceContainerClass="pv1 normal c-muted-2"
           listPriceLabelClass={listPriceLabelClasses}
           listPriceClass={listPriceClasses}
-          sellingPriceContainerClass="pt1 pb3 c-muted-1"
+          sellingPriceContainerClass="pt1 pb3 c-on-base"
           sellingPriceLabelClass="dib"
           sellingPriceClass="dib ph2 t-heading-5"
           savingsContainerClass="t-small-ns c-muted-2"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change price color from `c-muted-1` to `c-on-base`.

#### What problem is this solving?

Price color must to be `c-on-base`.

#### How should this be manually tested?

[Access this workspace](https://orderby--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
