### PR TITLE
Fix price and name container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed 
-- Fix price container's height.
+- Fix price and name container's height.
 
 ## [2.3.3] - 2019-01-04
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Fix price container's height.
 
 ## [2.3.3] - 2019-01-04
 ### Fixed 

--- a/react/index.js
+++ b/react/index.js
@@ -169,9 +169,10 @@ class ProductSummary extends Component {
       showBorders
     } = this.props
 
-    const containerClasses = classNames(`${productSummary.priceContainer} flex flex-column`, {
+    const containerClasses = classNames(`flex flex-column`, {
       'justify-end items-center': displayMode !== 'inline',
-      'pv5': !showBorders
+      'pv5': !showBorders,
+      [`${productSummary.priceContainer}`] : !showBorders
     })
 
     return (
@@ -204,17 +205,20 @@ class ProductSummary extends Component {
     const {
       displayMode,
       product,
+      showBorders,
       name: showFieldsProps
     } = this.props
+    console.log(showBorders)
 
     const containerClasses = classNames(
-      `${productSummary.nameContainer} flex items-start`,
+      `flex items-start`,
       {
         'justify-center': displayMode !== 'inline',
         'justify-left w-100': displayMode === 'inline',
         'pv5': displayMode === 'small',
         't-mini pb2': displayMode !== 'normal',
         'pv6': displayMode === 'normal',
+        [`${productSummary.nameContainer}`] : showBorders,
       }
     )
 

--- a/react/index.js
+++ b/react/index.js
@@ -304,9 +304,9 @@ class ProductSummary extends Component {
 
     const classes = classNames(`${productSummary.container} overflow-hidden br3 w-100 h-100`, {
       'flex flex-column justify-between center tc': displayMode !== 'inline',
-      [productSummary.containerNormal]: displayMode === 'normal',
-      [productSummary.containerSmall]: displayMode === 'small',
-      [productSummary.containerInline]: displayMode === 'inline',
+      [`${productSummary.containerNormal}`]: displayMode === 'normal',
+      [`${productSummary.containerSmall}`]: displayMode === 'small',
+      [`${productSummary.containerInline}`]: displayMode === 'inline',
     })
 
     const linkClasses = classNames(`${productSummary.clearLink} flex`, {

--- a/react/index.js
+++ b/react/index.js
@@ -171,7 +171,7 @@ class ProductSummary extends Component {
 
     const containerClasses = classNames('flex flex-column', {
       'justify-end items-center': displayMode !== 'inline',
-      [`${productSummary.priceContainer} pv5`] : !showBorders
+      [`${productSummary.priceContainer} pv5`]: !showBorders
     })
 
     return (
@@ -216,7 +216,7 @@ class ProductSummary extends Component {
         'pv5': displayMode === 'small',
         't-mini pb2': displayMode !== 'normal',
         'pv6': displayMode === 'normal',
-        [`${productSummary.nameContainer}`] : !showBorders,
+        [productSummary.nameContainer]: !showBorders,
         'pb6': showBorders,
       }
     )
@@ -304,9 +304,9 @@ class ProductSummary extends Component {
 
     const classes = classNames(`${productSummary.container} overflow-hidden br3 w-100 h-100`, {
       'flex flex-column justify-between center tc': displayMode !== 'inline',
-      [`${productSummary.containerNormal}`]: displayMode === 'normal',
-      [`${productSummary.containerSmall}`]: displayMode === 'small',
-      [`${productSummary.containerInline}`]: displayMode === 'inline',
+      [productSummary.containerNormal]: displayMode === 'normal',
+      [productSummary.containerSmall]: displayMode === 'small',
+      [productSummary.containerInline]: displayMode === 'inline',
     })
 
     const linkClasses = classNames(`${productSummary.clearLink} flex`, {

--- a/react/index.js
+++ b/react/index.js
@@ -208,7 +208,6 @@ class ProductSummary extends Component {
       showBorders,
       name: showFieldsProps
     } = this.props
-    console.log(showBorders)
 
     const containerClasses = classNames(
       `flex items-start`,

--- a/react/index.js
+++ b/react/index.js
@@ -171,8 +171,7 @@ class ProductSummary extends Component {
 
     const containerClasses = classNames('flex flex-column', {
       'justify-end items-center': displayMode !== 'inline',
-      'pv5': !showBorders,
-      [`${productSummary.priceContainer}`] : !showBorders
+      [`${productSummary.priceContainer} pv5`] : !showBorders
     })
 
     return (

--- a/react/index.js
+++ b/react/index.js
@@ -169,7 +169,7 @@ class ProductSummary extends Component {
       showBorders
     } = this.props
 
-    const containerClasses = classNames(`flex flex-column`, {
+    const containerClasses = classNames('flex flex-column', {
       'justify-end items-center': displayMode !== 'inline',
       'pv5': !showBorders,
       [`${productSummary.priceContainer}`] : !showBorders
@@ -210,7 +210,7 @@ class ProductSummary extends Component {
     } = this.props
 
     const containerClasses = classNames(
-      `flex items-start`,
+      'flex items-start',
       {
         'justify-center': displayMode !== 'inline',
         'justify-left w-100': displayMode === 'inline',

--- a/react/index.js
+++ b/react/index.js
@@ -205,19 +205,17 @@ class ProductSummary extends Component {
     const {
       displayMode,
       product,
-      showBorders,
       name: showFieldsProps
     } = this.props
 
     const containerClasses = classNames(
-      `flex items-start`,
+      `${productSummary.nameContainer} flex items-start`,
       {
         'justify-center': displayMode !== 'inline',
         'justify-left w-100': displayMode === 'inline',
         'pv5': displayMode === 'small',
         't-mini pb2': displayMode !== 'normal',
         'pv6': displayMode === 'normal',
-        [`${productSummary.nameContainer}`] : showBorders,
       }
     )
 

--- a/react/index.js
+++ b/react/index.js
@@ -205,17 +205,20 @@ class ProductSummary extends Component {
     const {
       displayMode,
       product,
+      showBorders,
       name: showFieldsProps
     } = this.props
 
     const containerClasses = classNames(
-      `${productSummary.nameContainer} flex items-start`,
+      `flex items-start`,
       {
         'justify-center': displayMode !== 'inline',
         'justify-left w-100': displayMode === 'inline',
         'pv5': displayMode === 'small',
         't-mini pb2': displayMode !== 'normal',
         'pv6': displayMode === 'normal',
+        [`${productSummary.nameContainer}`] : !showBorders,
+        'pb6': showBorders,
       }
     )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
The fixed height of the price container was breaking components utilizing the product-summary.
![priceheight](https://user-images.githubusercontent.com/17649410/50832653-a12c4580-132d-11e9-9da9-c4216ef6e657.PNG)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Adjusting the height according to the location that is used without affect components that already use the product summary.

#### How should this be manually tested?
Add an item in minicart and note the shelf, search-result and minicart components. 

https://heightcontainerprice--storecomponents.myvtex.com

#### Screenshots or example usage

![heightpricenew](https://user-images.githubusercontent.com/17649410/50835023-52ce7500-1334-11e9-9f87-2d540de24981.PNG)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

