### PR TITLE
Fix buy button always showing on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Buy button always showing with on hover option.
 
 ## [2.3.3] - 2019-01-04
 ### Fixed 

--- a/react/index.js
+++ b/react/index.js
@@ -267,7 +267,7 @@ class ProductSummary extends Component {
     return (
       !equals(displayBuyButton, displayButtonTypes.DISPLAY_NONE.value) && (
         <div className={buyButtonClasses}>
-          <div className={`${productSummary.buyButton} center mw-100 ${!showBuyButton && 'isHidden'}`}>
+          <div className={`${productSummary.buyButton} center mw-100 ${!showBuyButton && productSummary.isHidden}`}>
             <BuyButton
               available={isAvailable}
               skuItems={


### PR DESCRIPTION
#### What is the purpose of this pull request?
Show buy button only on hover when the respective option is selected on storefront

#### What problem is this solving?
Buy button was always showing when on hover option was selected

#### How should this be manually tested?
[Access this workspace](https://fixtheo--storecomponents.myvtex.com/admin/cms/storefront)

#### Screenshots or example usage
![clipboard 2019-07-01 at 11 25 45 am](https://user-images.githubusercontent.com/5597778/50835342-37179e80-1335-11e9-98aa-0ce8655b066f.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
