### PR TITLE
Fix incorrect click area on product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Incorrect click area on product.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.11.3] - 2019-02-22
 ### Fixed 
 - Incorrect click area on product.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductSummaryInline.js
+++ b/react/components/ProductSummaryInline.js
@@ -34,7 +34,7 @@ class ProductSummaryInline extends Component {
       'overflow-hidden br3 h-100 w-100'
     )
 
-    const summaryClasses = classNames(`${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`, {
+    const summaryClasses = classNames(`${productSummary.element} ${productSummary.clearLink} pointer ph2 pt3 pb4 flex flex-column`, {
       'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
     })
 
@@ -61,12 +61,12 @@ class ProductSummaryInline extends Component {
         onMouseLeave={handleMouseLeave}
       >
         <Link
-          className={`${productSummary.clearLink} flex`}
+          className={summaryClasses}
           page={'store.product'}
           params={{ slug: path(['linkText'], product) }}
           onClick={actionOnClick}
         >
-          <article className={summaryClasses}>
+          <article className="flex">
             <div className={`${productSummary.imageContainer} db w-30`}>
               {path(['sku', 'image', 'imageUrl'], product)
                 ? <ProductImage {...imageProps} />

--- a/react/components/ProductSummaryInline.js
+++ b/react/components/ProductSummaryInline.js
@@ -60,13 +60,13 @@ class ProductSummaryInline extends Component {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <article className={summaryClasses}>
-          <Link
-            className={`${productSummary.clearLink} flex`}
-            page={'store.product'}
-            params={{ slug: path(['linkText'], product) }}
-            onClick={actionOnClick}
-          >
+        <Link
+          className={`${productSummary.clearLink} flex`}
+          page={'store.product'}
+          params={{ slug: path(['linkText'], product) }}
+          onClick={actionOnClick}
+        >
+          <article className={summaryClasses}>
             <div className={`${productSummary.imageContainer} db w-30`}>
               {path(['sku', 'image', 'imageUrl'], product)
                 ? <ProductImage {...imageProps} />
@@ -85,9 +85,9 @@ class ProductSummaryInline extends Component {
                 <ProductSummaryPrice {...priceProps} {...priceClasses} />
               </div>
             </div>
-          </Link>
-          <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
-        </article>
+          </article>
+          <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} /> 
+        </Link>
       </section>
     )
   }

--- a/react/components/ProductSummaryNormal.js
+++ b/react/components/ProductSummaryNormal.js
@@ -63,13 +63,13 @@ class ProductSummaryNormal extends Component {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <article className={summaryClasses}>
-          <Link
-            className={`${productSummary.clearLink} h-100 flex flex-column`}
-            page={'store.product'}
-            params={{ slug: path(['linkText'], product) }}
-            onClick={actionOnClick}
-          >
+        <Link
+          className={`${productSummary.clearLink} h-100 flex flex-column`}
+          page={'store.product'}
+          params={{ slug: path(['linkText'], product) }}
+          onClick={actionOnClick}
+        >
+          <article className={summaryClasses}>
             <div className={`${productSummary.imageContainer} db w-100 center`}>
               {path(['sku', 'image', 'imageUrl'], product)
                 ? <ProductImage {...imageProps} />
@@ -88,9 +88,9 @@ class ProductSummaryNormal extends Component {
                 <ProductSummaryPrice {...priceProps} {...priceClasses} />
               </div>
             </div>
-          </Link>
+          </article>
           <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
-        </article>
+        </Link>
       </section>
     )
   }

--- a/react/components/ProductSummarySmall.js
+++ b/react/components/ProductSummarySmall.js
@@ -58,13 +58,13 @@ class ProductSummarySmall extends Component {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <article className={summaryClasses}>
-          <Link
-            className={`${productSummary.clearLink} flex flex-column`}
-            page={'store.product'}
-            params={{ slug: path(['linkText'], product) }}
-            onClick={actionOnClick}
-          >
+        <Link
+          className={`${productSummary.clearLink} flex flex-column`}
+          page={'store.product'}
+          params={{ slug: path(['linkText'], product) }}
+          onClick={actionOnClick}
+        >
+          <article className={summaryClasses}>
             <div className={`${productSummary.imageContainer} db w-100 center`}>
               {path(['sku', 'image', 'imageUrl'], product)
                 ? <ProductImage {...imageProps} />
@@ -77,9 +77,9 @@ class ProductSummarySmall extends Component {
                 <ProductSummaryPrice {...priceProps} {...priceClasses} />
               </div>
             </div>
-          </Link>
+          </article>
           <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
-        </article>
+        </Link>
       </section>
     )
   }

--- a/react/index.js
+++ b/react/index.js
@@ -156,7 +156,7 @@ class ProductSummary extends Component {
         showDescription={showDescription}
         handleMouseEnter={this.handleMouseEnter}
         handleMouseLeave={this.handleMouseLeave}
-        handleItemsStateUpdate={this.handleItemsStateUpdate}
+        handleItemsStateUpdate={this.handleItemsStateUpdate }
         actionOnClick={actionOnClick}
         imageProps={imageProps}
         nameProps={nameProps}

--- a/react/index.js
+++ b/react/index.js
@@ -156,7 +156,7 @@ class ProductSummary extends Component {
         showDescription={showDescription}
         handleMouseEnter={this.handleMouseEnter}
         handleMouseLeave={this.handleMouseLeave}
-        handleItemsStateUpdate={this.handleItemsStateUpdate }
+        handleItemsStateUpdate={this.handleItemsStateUpdate}
         actionOnClick={actionOnClick}
         imageProps={imageProps}
         nameProps={nameProps}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix incorrect click area on the product.

#### What problem is this solving?
The product summary has an area that is clickable but nothing happens. All the product area clicks must redirect to the product page, with the exception of the buy button area.

#### How should this be manually tested?
[Access this](https://clickare--storecomponents.myvtex.com/)

#### Screenshots or example usage
https://lh6.googleusercontent.com/aGXEjI_WZag1OwPM5c5A2VcbVoAssYvUJp9lwKuo3QPKHorQPn8uFeOM0hVZT8k85YydhTss1q0yFlnbuK7R-bgEKgRIHU4YhTCzS4LkJgDou-tLIAJ8yZOTTN9jFeWOLgVfZKE9

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.