### PR TITLE
Fix image size and use Img tag instead of background url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use smaller images to improve performance and replace background url by `<img>`.
+- Use smaller images to improve performance and replace background url with `<img>`.
 
 ## [2.4.1] - 2019-01-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use smaller images to improve performance.
 
 ## [2.4.1] - 2019-01-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use smaller images to improve performance.
+- Use smaller images to improve performance and replace background url by `<img>`.
 
 ## [2.4.1] - 2019-01-14
 ### Fixed

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -4,11 +4,24 @@ import PropTypes from 'prop-types'
 import productSummary from '../productSummary.css'
 
 /** Image component with 1:1 aspect ratio */
-export default function Image({ src, className }) {
+export default function Image({ src, className, width = 'auto', height = 'auto'}) {
+  const resizeSrc = src => {
+    //Check of src is already in a size defined by the client
+    const isWithMeasures = new RegExp(/[1-9]+-(:?([1-9]+)|(auto))/);
+    if (isWithMeasures.exec(src)) {
+      return src
+    }
+
+    const imageId = src.slice(src.indexOf("/ids/")).split("/")[2]
+    const withSuffix = `${imageId}-${width}-${height}`
+
+    return src.replace(imageId, withSuffix)
+  }
+
   return (
     <div
       className={`${className} ${productSummary.aspectRatio} w-100`}
-      style={{ backgroundImage: `url(${src})` }}
+      style={{ backgroundImage: `url(${resizeSrc(src)})` }}
     />
   )
 }
@@ -18,4 +31,8 @@ Image.propTypes = {
   src: PropTypes.string.isRequired,
   /** Custom classes */
   className: PropTypes.string,
+  /** Image width */
+  width: PropTypes.number,
+  /** Image height */
+  height: PropTypes.number,
 }

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import productSummary from '../productSummary.css'
 
 /** Image component with 1:1 aspect ratio */
-export default function Image({ src, className, width = 'auto', height = 'auto'}) {
+export default function Image({ src, className, width, height }) {
   const resizeSrc = src => {
     //Check of src is already in a size defined by the client
     const isWithMeasures = new RegExp(/[1-9]+-(:?([1-9]+)|(auto))/);
@@ -26,13 +26,24 @@ export default function Image({ src, className, width = 'auto', height = 'auto'}
   )
 }
 
+Image.defaultProps = {
+  width: 'auto',
+  height: 'auto',
+}
+
 Image.propTypes = {
   /** Image url */
   src: PropTypes.string.isRequired,
   /** Custom classes */
   className: PropTypes.string,
   /** Image width */
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.oneOf(['auto'])
+  ]),
   /** Image height */
-  height: PropTypes.number,
+  height: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.oneOf(['auto'])
+  ]),
 }

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import {path} from 'ramda'
 
 import productSummary from '../productSummary.css'
 
@@ -12,7 +13,7 @@ export default function Image({ src, className, width, height, alt }) {
       return src
     }
 
-    const imageId = src.slice(src.indexOf("/ids/")).split("/")[2]
+    const imageId = path('2', src.slice(src.indexOf("/ids/")).split("/"))
     const withSuffix = `${imageId}-${width}-${height}`
 
     return src.replace(imageId, withSuffix)

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import productSummary from '../productSummary.css'
 
 /** Image component with 1:1 aspect ratio */
-export default function Image({ src, className, width, height }) {
+export default function Image({ src, className, width, height, alt }) {
   const resizeSrc = src => {
     //Check of src is already in a size defined by the client
     const isWithMeasures = new RegExp(/[1-9]+-(:?([1-9]+)|(auto))/);
@@ -19,9 +19,8 @@ export default function Image({ src, className, width, height }) {
   }
 
   return (
-    <div
-      className={`${className} ${productSummary.aspectRatio} w-100`}
-      style={{ backgroundImage: `url(${resizeSrc(src)})` }}
+    <img alt={alt}
+      className={`${className} ${productSummary.aspectRatio} w-100`} src={resizeSrc(src)}
     />
   )
 }

--- a/react/components/Image.js
+++ b/react/components/Image.js
@@ -21,7 +21,7 @@ export default function Image({ src, className, width, height, alt }) {
 
   return (
     <img alt={alt}
-      className={`${className} ${productSummary.aspectRatio} w-100`} src={resizeSrc(src)}
+      className={`${className} ${productSummary.aspectRatio} ${productSummary.imageContainer} w-100`} src={resizeSrc(src)}
     />
   )
 }

--- a/react/index.js
+++ b/react/index.js
@@ -112,6 +112,7 @@ class ProductSummary extends Component {
 
   get renderImage() {
     const { product, showBadge, badgeText, showCollections, imageWidth, imageHeight } = this.props
+    
     const {
       productClusters,
       productName: name,

--- a/react/index.js
+++ b/react/index.js
@@ -60,13 +60,19 @@ class ProductSummary extends Component {
       }),
     }),
     /** Display mode of the summary used in the search result */
-    displayMode: PropTypes.oneOf([
-      'normal',
-      'small',
-      'inline',
-    ]),
+    displayMode: PropTypes.oneOf(['normal', 'small', 'inline']),
     /** Function that is executed when a product is clicked */
     actionOnClick: PropTypes.func,
+    /** Image height */
+    imageHeight: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf(['auto'])
+    ]),
+    /** Image width */
+    imageWidth: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf(['auto'])
+    ]),
   }
 
   static defaultProps = {
@@ -85,6 +91,7 @@ class ProductSummary extends Component {
     },
     displayMode: 'normal',
     showBorders: false,
+    imageWidth: 500,
   }
 
   state = {
@@ -104,7 +111,7 @@ class ProductSummary extends Component {
   }
 
   get renderImage() {
-    const { product, showBadge, badgeText, showCollections } = this.props
+    const { product, showBadge, badgeText, showCollections, imageWidth, imageHeight } = this.props
     const {
       productClusters,
       productName: name,
@@ -114,7 +121,7 @@ class ProductSummary extends Component {
     } = product
 
     let img = (
-      <Image className={`${productSummary.image}`} alt={name} src={imageUrl} />
+      <Image className={`${productSummary.image}`} alt={name} src={imageUrl} width={imageWidth} height={imageHeight}/>
     )
 
     if (showBadge) {

--- a/react/index.js
+++ b/react/index.js
@@ -112,7 +112,7 @@ class ProductSummary extends Component {
 
   get renderImage() {
     const { product, showBadge, badgeText, showCollections, imageWidth, imageHeight } = this.props
-    console.log(product)
+    
     const {
       productClusters,
       productName: name,

--- a/react/index.js
+++ b/react/index.js
@@ -112,17 +112,18 @@ class ProductSummary extends Component {
 
   get renderImage() {
     const { product, showBadge, badgeText, showCollections, imageWidth, imageHeight } = this.props
-    
+    console.log(product)
     const {
       productClusters,
       productName: name,
       sku: {
         image: { imageUrl },
+        name: skuName,
       },
     } = product
 
     let img = (
-      <Image className={`${productSummary.image}`} alt={name} src={imageUrl} width={imageWidth} height={imageHeight}/>
+      <Image className={`${productSummary.image}`} alt={`${name} - ${skuName}`} src={imageUrl} width={imageWidth} height={imageHeight}/>
     )
 
     if (showBadge) {

--- a/react/index.js
+++ b/react/index.js
@@ -91,7 +91,7 @@ class ProductSummary extends Component {
     },
     displayMode: 'normal',
     showBorders: false,
-    imageWidth: 500,
+    imageWidth: 546,
   }
 
   state = {

--- a/react/index.js
+++ b/react/index.js
@@ -63,13 +63,13 @@ class ProductSummary extends Component {
     displayMode: PropTypes.oneOf(['normal', 'small', 'inline']),
     /** Function that is executed when a product is clicked */
     actionOnClick: PropTypes.func,
-    /** Image height */
-    imageHeight: PropTypes.oneOfType([
+    /** Image width */
+    imageWidth: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.oneOf(['auto'])
     ]),
-    /** Image width */
-    imageWidth: PropTypes.oneOfType([
+    /** Image height */
+    imageHeight: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.oneOf(['auto'])
     ]),

--- a/react/productSummary.css
+++ b/react/productSummary.css
@@ -8,6 +8,7 @@
 .image {}
 .buyButtonContainer {}
 .buyButton {}
+.aspectRatio {}
 
 .isHidden {
   visibility: hidden;
@@ -20,11 +21,6 @@
 .clearLink {
   text-decoration: inherit;
   color: inherit;
-}
-
-.aspectRatio {
-  padding-top: 100%;
-  background: center / contain no-repeat;
 }
 
 .nameContainer {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Use resized images in product-summary instead of the original image.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Even though the image needed in this component was small, it always loaded the maximum size of the image. Now it loads with 500px, also making it possible to customize this value through props.

#### How should this be manually tested?
[workspace](https://imageresizeps--storecomponents.myvtex.com/)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
