### PR TITLE
Use ProductName as H2 element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.2] - 2019-01-26
 - Use `ProductName` as H2 element.
 
 ## [2.9.1] - 2019-01-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Use `ProductName` as H2 element.
 
 ## [2.9.1] - 2019-01-26
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductSummaryName.js
+++ b/react/components/ProductSummaryName.js
@@ -34,6 +34,7 @@ const ProductSummaryName = ({ displayMode, product, name }) => {
         name={productName}
         skuName={skuName}
         brandName={brandName}
+        tag="h2"
         {...name}
       />
     </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We basically do not use header elements (h1, h2, h3) in our components and it is desirable to use these elements to make our html codebase more meaningful (by adding semantic html elements).

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
ProductName in product-summary used as H2 element instead of a div with spans.

#### How should this be manually tested?
[https://alves--storecomponents.myvtex.com/](https://alves--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
