### PR TITLE
Fix/inline size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Add w-100 to inline container
+- Make inline content occupy full width
+- While updating item quantity, show spinner over price
 
 ## [2.9.4] - 2019-01-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Make inline content occupy full width
 - While updating item quantity, show spinner over price
+- Make price and quantity stepper align on baseline and not center
 
 ## [2.9.4] - 2019-01-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add w-100 to inline container
 
 ## [2.9.4] - 2019-01-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.5] - 2019-01-28
 ### Fixed
 - Make inline content occupy full width
 - While updating item quantity, show spinner over price

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/index.js
+++ b/react/index.js
@@ -298,7 +298,7 @@ class ProductSummary extends Component {
     })
 
     const priceWrapperClasses = classNames({
-      'flex justify-between items-center': displayMode === 'inline',
+      'flex justify-between items-baseline': displayMode === 'inline',
     })
 
     const buyButtonProps = {

--- a/react/index.js
+++ b/react/index.js
@@ -3,6 +3,7 @@ import { path } from 'ramda'
 import React, { Component } from 'react'
 import ContentLoader from 'react-content-loader'
 import { Link, withRuntimeContext } from 'vtex.render-runtime'
+import { Spinner } from 'vtex.styleguide'
 import classNames from 'classnames'
 import {
   CollectionBadges,
@@ -175,6 +176,14 @@ class ProductSummary extends Component {
       labelSellingPrice,
       displayMode,
     } = this.props
+
+    if (this.state.isUpdatingItems) {
+      return (
+        <div className="flex items-center justify-center w-100">
+          <Spinner size={20} />
+        </div>
+      )
+    }
 
     const containerClasses = classNames('flex flex-column', {
       'justify-end items-center': displayMode !== 'inline',

--- a/react/index.js
+++ b/react/index.js
@@ -268,7 +268,7 @@ class ProductSummary extends Component {
       'flex flex-column justify-between center tc': displayMode !== 'inline',
       [`${productSummary.containerNormal}`]: displayMode === 'normal',
       [`${productSummary.containerSmall}`]: displayMode === 'small',
-      [`${productSummary.containerInline}`]: displayMode === 'inline',
+      [`${productSummary.containerInline} w-100`]: displayMode === 'inline',
     })
 
     const linkClasses = classNames(`${productSummary.clearLink} flex`, {


### PR DESCRIPTION
A pr 95 quebrou o style do modo inline.


Workspace: inline--storecomponents

Quebrado:

<img width="387" alt="screen shot 2019-01-28 at 4 01 50 pm" src="https://user-images.githubusercontent.com/4925068/51856785-b76b6700-2317-11e9-80c4-2a3ad9d5a959.png">

Consertado:
<img width="363" alt="screen shot 2019-01-28 at 4 10 49 pm" src="https://user-images.githubusercontent.com/4925068/51856787-b76b6700-2317-11e9-9d90-a8c85a0b47fe.png">
#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
