### PR TITLE
fix price size for inline mode and image container size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.9] - 2019-01-30
 ### Fixed
 - Image container and info size proportion for inline mode
 - Make price font smaller if price > 100 in inline mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Image container and info size proportion for inline mode
+- Make price font smaller if price > 100 in inline mode
 
 ## [2.9.8] - 2019-01-30
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductQuantityStepper.js
+++ b/react/components/ProductQuantityStepper.js
@@ -69,6 +69,7 @@ class ProductQuantityStepper extends Component {
     return (
       <NumericStepper
         lean
+        size="small"
         value={this.state.quantity}
         minValue={1}
         maxValue={this.state.canIncrease ? undefined : this.state.quantity}

--- a/react/components/ProductSummaryPrice.js
+++ b/react/components/ProductSummaryPrice.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { path } from 'ramda'
+import { path, prop } from 'ramda'
 import classNames from 'classnames'
 import { Spinner } from 'vtex.styleguide'
 import { ProductPrice } from 'vtex.store-components'
@@ -36,6 +36,11 @@ const ProductSummaryPrice = ({
     [`${productSummary.priceContainer} pv5`]: !showBorders,
   })
 
+  const sellingPrice = prop('Price')(commertialOffer)
+  const sellingPriceClass = classNames('dib ph2 t-body t-heading-5-ns', {
+    't-small t-body-ns': sellingPrice > 1000 && displayMode === 'inline',
+  })
+
   return (
     <div className={containerClasses}>
       <ProductPrice
@@ -45,14 +50,14 @@ const ProductSummaryPrice = ({
         listPriceClass="dib ph2 strike t-small-ns t-mini"
         sellingPriceContainerClass="pt1 pb3 c-on-base"
         sellingPriceLabelClass="dib"
-        sellingPriceClass="dib ph2 t-heading-5-ns"
+        sellingPriceClass={sellingPriceClass}
         savingsContainerClass="t-small-ns c-muted-2"
         savingsClass="dib"
         interestRateClass="dib pl2"
         installmentContainerClass="t-small-ns c-muted-2"
-        listPrice={path(['ListPrice'], commertialOffer)}
-        sellingPrice={path(['Price'], commertialOffer)}
-        installments={path(['Installments'], commertialOffer)}
+        listPrice={prop('ListPrice', commertialOffer)}
+        sellingPrice={sellingPrice}
+        installments={prop('Installments', commertialOffer)}
         showListPrice={showListPrice}
         showLabels={showLabels}
         showInstallments={showInstallments}

--- a/react/components/ProductSummaryPrice.js
+++ b/react/components/ProductSummaryPrice.js
@@ -36,7 +36,7 @@ const ProductSummaryPrice = ({
     [`${productSummary.priceContainer} pv5`]: !showBorders,
   })
 
-  const sellingPrice = prop('Price')(commertialOffer)
+  const sellingPrice = prop('Price', commertialOffer)
   const sellingPriceClass = classNames('dib ph2 t-body t-heading-5-ns', {
     't-small t-body-ns': sellingPrice > 1000 && displayMode === 'inline',
   })

--- a/react/index.js
+++ b/react/index.js
@@ -140,11 +140,11 @@ class ProductSummary extends Component {
 
     const imageContainerClasses = classNames(`${productSummary.imageContainer} db`, {
       'w-100 center': displayMode !== 'inline',
-      'w-40': displayMode === 'inline',
+      'w-30': displayMode === 'inline',
     })
 
     const informationClasses = classNames(`${productSummary.information}`, {
-      'w-80 pb2 pl3 pr3 flex flex-column justify-between': displayMode === 'inline',
+      'w-70 pb2 pl3 pr3 flex flex-column justify-between': displayMode === 'inline',
     })
 
     const elementClasses = classNames(`${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`, {


### PR DESCRIPTION
Correct the proportion between image container and info container, their combined width was 120% and was causing an issue while updating item quantity. (The layout was changing and getting weird).

After correcting this, when the price was getting above 1000, it was breaking layout and not fitting the screen, specially with the big `MX` for the Mexican currency.

After
Mobile:
<img width="356" alt="screen shot 2019-01-30 at 6 17 31 pm" src="https://user-images.githubusercontent.com/4925068/52010908-cf7ceb00-24bd-11e9-8de9-0a772858fe49.png">
<img width="361" alt="screen shot 2019-01-30 at 6 17 41 pm" src="https://user-images.githubusercontent.com/4925068/52010910-d0158180-24bd-11e9-9d6d-ec335c51dde8.png">

Desktop:
<img width="386" alt="screen shot 2019-01-30 at 6 42 50 pm" src="https://user-images.githubusercontent.com/4925068/52011365-e839d080-24be-11e9-81d4-1f0d893ba872.png">
<img width="406" alt="screen shot 2019-01-30 at 6 42 58 pm" src="https://user-images.githubusercontent.com/4925068/52011367-e839d080-24be-11e9-83f6-64d684a6bb76.png">


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
