### PR TITLE
Add better guard in ProductImage when productClusters is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add better guard in `ProductImage` when productClusters is empty.
 
 ## [2.9.9] - 2019-01-30
 ### Fixed

--- a/react/components/ProductImage.js
+++ b/react/components/ProductImage.js
@@ -27,7 +27,7 @@ const maybeBadge = ({ listPrice, price, label }) => condition => component => {
 }
 
 const maybeCollection = ({ productClusters }) => condition => component => {
-  if (condition) {
+  if (condition && !isEmpty(productClusters)) {
     const collections = productClusters.map(cl => cl.name)
     return (
       <CollectionBadges collectionBadgesText={collections}>
@@ -53,7 +53,7 @@ const ProductImage = ({ product, showBadge, badgeText, showCollections }) => {
   const withCollection = maybeCollection({ productClusters })
   const img = (<Image className={productSummary.image} alt={name} src={imageUrl} />)
 
-  return compose(withBadge(showBadge), withCollection(showCollections && !isEmpty(productClusters)))(img)
+  return compose(withBadge(showBadge), withCollection(showCollections))(img)
 }
 
 ProductImage.propTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
As described in the title.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Here](https://extractcomponentsproductsummary--storecomponents.myvtex.com/)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
