### PR TITLE
Fix Ramda isEmpty misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.11] - 2019-02-01
 ### Fixed
 - Fix misuse of `isEmpty` from `Ramda`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix misuse of `isEmpty` from `Rambda`.
+- Fix misuse of `isEmpty` from `Ramda`.
 
 ## [2.9.10] - 2019-01-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix misuse of `isEmpty` from `Rambda`.
 
 ## [2.9.10] - 2019-01-31
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductImage.js
+++ b/react/components/ProductImage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { pathOr, isEmpty, compose } from 'ramda'
+import { pathOr, compose } from 'ramda'
 import PropTypes from 'prop-types'
 import {
   CollectionBadges,
@@ -27,7 +27,7 @@ const maybeBadge = ({ listPrice, price, label }) => shouldShow => component => {
 }
 
 const maybeCollection = ({ productClusters }) => shouldShow => component => {
-  if (shouldShow && !isEmpty(productClusters)) {
+  if (shouldShow && productClusters && productClusters.length > 0) {
     const collections = productClusters.map(cl => cl.name)
     return (
       <CollectionBadges collectionBadgesText={collections}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
`Ramda` `isEmpty` function was being misused because when receiving `undefined` or `null` it would return `false`.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
When seeing any page with `product-kit` the following error would show:
```
TypeError: Cannot read property 'map' of undefined
    at https://icons--storecomponents.myvtex.com/_v/public/assets/v1/published/vtex.product-summary@2.9.10/public/react/index.js:968:43
    at https://icons--storecomponents.myvtex.com/_v/public/assets/v1/published/vtex.product-summary@2.9.10/public/react/index.js:25613:27
    at https://icons--storecomponents.myvtex.com/_v/public/assets/v1/published/vtex.product-summary@2.9.10/public/react/index.js:24372:19
    at ProductImage (https://icons--storecomponents.myvtex.com/_v/public/assets/v1/published/vtex.product-summary@2.9.10/public/react/index.js:998:118)
    at mountIndeterminateComponent (https://icons--storecomponents.myvtex.com/_v/public/assets/v1/npm/react-dom@16.7.0/umd/react-dom.development.js:14938:13)
    at beginWork (https://icons--storecomponents.myvtex.com/_v/public/assets/v1/npm/react-dom@16.7.0/umd/react-dom.development.js:15443:16)
    at performUnitOfWork (https://icons--storecomponents.myvtex.com/_v/public/assets/v1/npm/react-dom@16.7.0/umd/react-dom.develop
```

#### How should this be manually tested?
[Here](https://extractcomponentsproductsummary--storecomponents.myvtex.com)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
