### PR TITLE
Update BuyButton items props to use the Minicart's optimistic strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Create a API Docs.
+- Add the optimistic minicart strategy props.
 
 ## [2.10.6] - 2019-02-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Create a API Docs.
-- Add the optimistic minicart strategy props.
+- Add the optimistic minicart strategy props to the `BuyButton`.
 
 ## [2.10.6] - 2019-02-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.11.0] - 2019-02-13
 ### Added
 - Create a API Docs.
 - Add the optimistic minicart strategy props to the `BuyButton`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.10.6",
+  "version": "2.11.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton.js
@@ -39,6 +39,12 @@ const ProductSummaryBuyButton = ({
           skuItems={
             path(['sku', 'itemId'], product) && [
               {
+                /* Optimistic props */
+                detailUrl: `/${product.linkText}/p`,
+                imageUrl: path(['sku', 'image', 'imageUrl'], product),
+                listPrice: path(['sku', 'seller', 'commertialOffer', 'ListPrice'], product),
+                /* End Optimistic props */
+
                 skuId: path(['sku', 'itemId'], product),
                 quantity: 1,
                 seller: path(['sku', 'seller', 'sellerId'], product),

--- a/react/components/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton.js
@@ -39,12 +39,9 @@ const ProductSummaryBuyButton = ({
           skuItems={
             path(['sku', 'itemId'], product) && [
               {
-                /* Optimistic props */
                 detailUrl: `/${product.linkText}/p`,
                 imageUrl: path(['sku', 'image', 'imageUrl'], product),
                 listPrice: path(['sku', 'seller', 'commertialOffer', 'ListPrice'], product),
-                /* End Optimistic props */
-
                 skuId: path(['sku', 'itemId'], product),
                 quantity: 1,
                 seller: path(['sku', 'seller', 'sellerId'], product),


### PR DESCRIPTION
**Related to vtex-apps/minicart#93**

#### What is the purpose of this pull request?

Update the buy-button items props so the product-summary can use the minicart's optimistic strategy.

#### What problem is this solving?

Outdated props.

#### How should this be manually tested?

[Access the workspace](https://offline--storecomponents.myvtex.com)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
