### PR TITLE
Fix/show rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.3] - 2019-02-08
 ### Fixed
 - Use initialQuantity of item composition to decide what attachment to show
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use initialQuantity of item composition to decide what attachment to show
 
 ## [2.10.2] - 2019-02-07
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/AttachmentList.js
+++ b/react/components/AttachmentList.js
@@ -21,11 +21,12 @@ class AttachmentList extends Component {
   }
 
   formatAttachmentName = (option) => {
+    const { product, intl } = this.props
     const extraParams = {
       name: option.productName,
-      quantity: this.getOptionExtraQuantity(option),
+      quantity: this.getOptionExtraQuantity(option) || (option.quantity / product.quantity),
     }
-    return this.props.intl.formatMessage({ id: 'editor.productSummary.attachmentName' }, extraParams)
+    return intl.formatMessage({ id: 'editor.productSummary.attachmentName' }, extraParams)
   }
     
 

--- a/react/components/ProductSummaryInline.js
+++ b/react/components/ProductSummaryInline.js
@@ -35,7 +35,7 @@ class ProductSummaryInline extends Component {
     )
 
     const summaryClasses = classNames(`${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`, {
-      'bb b--muted-4 mh2 mt2': showBorders,
+      'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
     })
 
     const nameClasses = {

--- a/react/utils/attachmentHelper.js
+++ b/react/utils/attachmentHelper.js
@@ -1,4 +1,4 @@
-import { path } from 'ramda'
+import { pathOr } from 'ramda'
 
 export const CHOICE_TYPES = {
   SINGLE: 'SINGLE',
@@ -6,7 +6,7 @@ export const CHOICE_TYPES = {
   TOGGLE: 'TOGGLE',
 }
 
-export const getProductPrice = (product) => path(['sku', 'seller', 'commertialOffer', 'Price'], product) || 0
+export const getProductPrice = (product) => pathOr(0, ['sku', 'seller', 'commertialOffer', 'Price'], product)
 
 export const parentPricePerUnit = product => {
   const wholePrice = getProductPrice(product)


### PR DESCRIPTION
https://initial2--phmex.myvtex.com

implements correct rule to choose what attachments it should show.


desktop:
<img width="352" alt="screen shot 2019-02-08 at 12 16 39 pm" src="https://user-images.githubusercontent.com/4925068/52483884-1775cf00-2b9c-11e9-8a34-4daf3d756725.png">
mobile:
<img width="257" alt="screen shot 2019-02-08 at 12 19 21 pm" src="https://user-images.githubusercontent.com/4925068/52483886-1775cf00-2b9c-11e9-9d26-e08f87375085.png">

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
