### PR TITLE
Add new product summary type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add new type of product summary (inline price).
+
 ## [2.12.0] - 2019-02-27
+
 ### Changed
+
 - Start using assembly resolvers from `store-graphql`
 
 ### Added
+
 - Show assembly options removed from item by user
 
 ### Fixed
@@ -27,7 +34,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add snapshot tests.
-- Add new type of product summary (inline price).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.13.0] - 2019-03-13
+
 ### Added
 
 - Add new type of product summary (inline price).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add snapshot tests.
+- Add new type of product summary (inline price).
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/__tests__/ProductSummary.test.js
+++ b/react/__tests__/ProductSummary.test.js
@@ -54,8 +54,13 @@ describe('<ProductSummary /> component', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('should match the snapshot for inline mode', () => {
+  it('should match the snapshot for inline normal mode', () => {
     const { asFragment } = renderComponent({ displayMode: 'inline' })
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should match the snapshot for inline price mode', () => {
+    const { asFragment } = renderComponent({ displayMode: 'inlinePrice' })
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/react/__tests__/__snapshots__/ProductSummary.test.js.snap
+++ b/react/__tests__/__snapshots__/ProductSummary.test.js.snap
@@ -6,7 +6,7 @@ exports[`<ProductSummary /> component should match the snapshot for inline norma
     class="container containerInline overflow-hidden br3 h-100 w-100"
   >
     <article
-      class="element pointer ph2 pt3 pb4 flex flex-column"
+      class="flex"
     >
       <div
         class="imageContainer db w-30"
@@ -63,7 +63,7 @@ exports[`<ProductSummary /> component should match the snapshot for inline price
     class="container containerInline overflow-hidden br3 h-100 w-100"
   >
     <article
-      class="flex"
+      class="element pointer ph2 pt3 pb4 flex flex-column"
     >
       <div
         class="imageContainer db w-30"
@@ -101,18 +101,18 @@ exports[`<ProductSummary /> component should match the snapshot for inline price
           </div>
         </div>
       </div>
-    </article>
-    <div
-      class="buyButtonContainer pv3 w-100 dn"
-    >
       <div
-        class="buyButton center mw-100"
+        class="buyButtonContainer pv3 w-100 dn"
       >
-        <div>
-          BuyButton
+        <div
+          class="buyButton center mw-100"
+        >
+          <div>
+            BuyButton
+          </div>
         </div>
       </div>
-    </div>
+    </article>
   </section>
 </DocumentFragment>
 `;

--- a/react/__tests__/__snapshots__/ProductSummary.test.js.snap
+++ b/react/__tests__/__snapshots__/ProductSummary.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<ProductSummary /> component should match the snapshot for inline normal mode 1`] = `
 <DocumentFragment>
   <section
-    class="container containerInline overflow-hidden br3 h-100 w-100"
+    class="container containerInlinePrice overflow-hidden br3 h-100 w-100"
   >
     <article
       class="flex"

--- a/react/__tests__/__snapshots__/ProductSummary.test.js.snap
+++ b/react/__tests__/__snapshots__/ProductSummary.test.js.snap
@@ -1,6 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ProductSummary /> component should match the snapshot for inline mode 1`] = `
+exports[`<ProductSummary /> component should match the snapshot for inline normal mode 1`] = `
+<DocumentFragment>
+  <section
+    class="container containerInline overflow-hidden br3 h-100 w-100"
+  >
+    <article
+      class="element pointer ph2 pt3 pb4 flex flex-column"
+    >
+      <div
+        class="imageContainer db w-30"
+      >
+        <div>
+          ContentLoader
+        </div>
+      </div>
+      <div
+        class="information w-70 pb2 pl3 pr3"
+      >
+        <div
+          class="flex items-start justify-left tl w-90 t-mini pb2"
+        >
+          <div>
+            ProductName
+          </div>
+        </div>
+        <div
+          class="nr2"
+        >
+          <div
+            class="flex flex-column nr1 priceContainer"
+          >
+            <div>
+              ProductPrice
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex"
+        >
+          <div
+            class="buyButtonContainer pv3 w-100"
+          >
+            <div
+              class="buyButton center mw-100"
+            >
+              <div>
+                BuyButton
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`<ProductSummary /> component should match the snapshot for inline price mode 1`] = `
 <DocumentFragment>
   <section
     class="container containerInline overflow-hidden br3 h-100 w-100"

--- a/react/__tests__/__snapshots__/ProductSummary.test.js.snap
+++ b/react/__tests__/__snapshots__/ProductSummary.test.js.snap
@@ -9,38 +9,42 @@ exports[`<ProductSummary /> component should match the snapshot for inline norma
       class="flex"
     >
       <div
-        class="imageContainer db w-30"
+        class="imageContainer db w-70"
       >
         <div>
           ContentLoader
         </div>
       </div>
       <div
-        class="information w-70 pb2 pl3 pr3"
+        class="information w-80 pb2 pl3 flex flex-wrap flex-column justify-between"
       >
         <div
-          class="flex items-start justify-left tl w-90 t-mini pb2"
-        >
-          <div>
-            ProductName
-          </div>
-        </div>
-        <div
-          class="nr2"
+          class="flex flex-column"
         >
           <div
-            class="flex flex-column nr1 priceContainer"
+            class="flex items-start justify-left tl w-90 t-mini pb2"
           >
             <div>
-              ProductPrice
+              ProductName
+            </div>
+          </div>
+          <div
+            class="nr2"
+          >
+            <div
+              class="flex flex-column nr1 priceContainer"
+            >
+              <div>
+                ProductPrice
+              </div>
             </div>
           </div>
         </div>
         <div
-          class="flex"
+          class="flex flex-column-reverse"
         >
           <div
-            class="buyButtonContainer pv3 w-100"
+            class="buyButtonContainer pt3 w-100"
           >
             <div
               class="buyButton center mw-100"

--- a/react/components/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton.js
@@ -12,53 +12,72 @@ const ProductSummaryBuyButton = ({
   displayBuyButton,
   isOneClickBuy,
   buyButtonText,
-  runtime: { hints: { mobile } },
+  runtime: {
+    hints: { mobile },
+  },
   isHovering,
   containerClass,
 }) => {
-
-  const hoverBuyButton = equals(displayBuyButton, displayButtonTypes.DISPLAY_ALWAYS.value) ||
+  const hoverBuyButton =
+    equals(displayBuyButton, displayButtonTypes.DISPLAY_ALWAYS.value) ||
     !equals(displayBuyButton, displayButtonTypes.DISPLAY_ON_HOVER.value) ||
     (isHovering && !mobile)
-    
-  const showBuyButton = !equals(displayBuyButton, displayButtonTypes.DISPLAY_NONE.value) &&
-    !(equals(displayBuyButton, displayButtonTypes.DISPLAY_ON_HOVER.value) && mobile)
 
-  const buyButtonClasses = classNames(`${productSummary.buyButton} center mw-100`, {
-    [productSummary.isHidden]: !hoverBuyButton,
-  })
+  const showBuyButton =
+    !equals(displayBuyButton, displayButtonTypes.DISPLAY_NONE.value) &&
+    !(
+      equals(displayBuyButton, displayButtonTypes.DISPLAY_ON_HOVER.value) &&
+      mobile
+    )
 
-  const quantity = path(['sku', 'seller', 'commertialOffer', 'AvailableQuantity'], product) || 0
-  const isAvailable = (quantity > 0)
+  const buyButtonClasses = classNames(
+    `${productSummary.buyButton} center mw-100`,
+    {
+      [productSummary.isHidden]: !hoverBuyButton,
+    }
+  )
 
-  return (showBuyButton && 
-    <div className={containerClass}>
-      <div className={buyButtonClasses}>
-        <BuyButton
-          available={isAvailable}
-          skuItems={
-            path(['sku', 'itemId'], product) && [
-              {
-                detailUrl: `/${product.linkText}/p`,
-                imageUrl: path(['sku', 'image', 'imageUrl'], product),
-                listPrice: path(['sku', 'seller', 'commertialOffer', 'ListPrice'], product),
-                skuId: path(['sku', 'itemId'], product),
-                quantity: 1,
-                seller: path(['sku', 'seller', 'sellerId'], product),
-                name: product.productName,
-                price: path(['sku', 'seller', 'commertialOffer', 'Price'], product),
-                variant: product.sku.name,
-                brand: product.brand,
-              },
-            ]
-          }
-          isOneClickBuy={isOneClickBuy}
-        >
-          {buyButtonText || <FormattedMessage id="button-label" />}
-        </BuyButton>
+  const quantity =
+    path(['sku', 'seller', 'commertialOffer', 'AvailableQuantity'], product) ||
+    0
+  const isAvailable = quantity > 0
+
+  return (
+    showBuyButton && (
+      <div className={containerClass}>
+        <div className={buyButtonClasses}>
+          <BuyButton
+            available={isAvailable}
+            skuItems={
+              path(['sku', 'itemId'], product) && [
+                {
+                  detailUrl: `/${product.linkText}/p`,
+                  imageUrl: path(['sku', 'image', 'imageUrl'], product),
+                  listPrice: path(
+                    ['sku', 'seller', 'commertialOffer', 'ListPrice'],
+                    product
+                  ),
+                  skuId: path(['sku', 'itemId'], product),
+                  quantity: 1,
+                  seller: path(['sku', 'seller', 'sellerId'], product),
+                  name: product.productName,
+                  price: path(
+                    ['sku', 'seller', 'commertialOffer', 'Price'],
+                    product
+                  ),
+                  variant: product.sku.name,
+                  brand: product.brand,
+                },
+              ]
+            }
+            isOneClickBuy={isOneClickBuy}
+          >
+            {buyButtonText || <FormattedMessage id="button-label" />}
+          </BuyButton>
         </div>
       </div>
     )
+  )
 }
 
 export default ProductSummaryBuyButton

--- a/react/components/ProductSummaryInline.js
+++ b/react/components/ProductSummaryInline.js
@@ -28,9 +28,9 @@ class ProductSummaryInline extends Component {
       buyButtonProps,
     } = this.props
 
-    const constainerClasses = classNames(
+    const containerClasses = classNames(
       productSummary.container,
-      productSummary.containerInline,
+      productSummary.containerInlinePrice,
       'overflow-hidden br3 h-100 w-100'
     )
 
@@ -61,7 +61,7 @@ class ProductSummaryInline extends Component {
 
     return (
       <section
-        className={constainerClasses}
+        className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >

--- a/react/components/ProductSummaryInline.js
+++ b/react/components/ProductSummaryInline.js
@@ -37,7 +37,7 @@ class ProductSummaryInline extends Component {
     const summaryClasses = classNames(
       `${productSummary.element} ${
         productSummary.clearLink
-      } pointer ph2 pt3 pb4 flex flex-column`,
+      } pointer pt3 pb4 flex flex-column`,
       {
         'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
       }
@@ -56,7 +56,7 @@ class ProductSummaryInline extends Component {
     }
 
     const buyButtonClasses = {
-      containerClass: `${productSummary.buyButtonContainer} pv3 w-100`,
+      containerClass: `${productSummary.buyButtonContainer} pt3 w-100`,
     }
 
     return (
@@ -72,20 +72,26 @@ class ProductSummaryInline extends Component {
           onClick={actionOnClick}
         >
           <article className="flex">
-            <div className={`${productSummary.imageContainer} db w-30`}>
+            <div className={`${productSummary.imageContainer} db w-70`}>
               {path(['sku', 'image', 'imageUrl'], product) ? (
                 <ProductImage {...imageProps} />
               ) : (
                 <ImageLoader />
               )}
             </div>
-            <div className={`${productSummary.information} w-70 pb2 pl3 pr3`}>
-              <ProductSummaryName {...nameProps} {...nameClasses} />
-              <AttachmentList product={product} />
-              <div className="nr2">
-                <ProductSummaryPrice {...priceProps} {...priceClasses} />
+            <div
+              className={`${
+                productSummary.information
+              } w-80 pb2 pl3 flex flex-wrap flex-column justify-between`}
+            >
+              <div className="flex flex-column">
+                <ProductSummaryName {...nameProps} {...nameClasses} />
+                <AttachmentList product={product} />
+                <div className="nr2">
+                  <ProductSummaryPrice {...priceProps} {...priceClasses} />
+                </div>
               </div>
-              <div className="flex">
+              <div className="flex flex-column-reverse">
                 <ProductSummaryBuyButton
                   {...buyButtonProps}
                   {...buyButtonClasses}

--- a/react/components/ProductSummaryInlinePrice.js
+++ b/react/components/ProductSummaryInlinePrice.js
@@ -13,84 +13,85 @@ import ProductSummaryName from './ProductSummaryName'
 
 import productSummary from '../productSummary.css'
 
-class ProductSummaryInline extends Component {
-  render() {
-    const {
-      product,
-      showBorders,
-      handleMouseEnter,
-      handleMouseLeave,
-      handleItemsStateUpdate,
-      actionOnClick,
-      imageProps,
-      nameProps,
-      priceProps,
-      buyButtonProps,
-    } = this.props
+const ProductSummaryInline = ({
+  product,
+  showBorders,
+  handleMouseEnter,
+  handleMouseLeave,
+  handleItemsStateUpdate,
+  actionOnClick,
+  imageProps,
+  nameProps,
+  priceProps,
+  buyButtonProps,
+}) => {
+  const containerClasses = classNames(
+    productSummary.container,
+    productSummary.containerInline,
+    'overflow-hidden br3 h-100 w-100'
+  )
 
-    const constainerClasses = classNames(
-      productSummary.container,
-      productSummary.containerInline,
-      'overflow-hidden br3 h-100 w-100'
-    )
-
-    const summaryClasses = classNames(`${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`, {
+  const summaryClasses = classNames(
+    `${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`,
+    {
       'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
-    })
-
-    const nameClasses = {
-      containerClass: 'flex items-start justify-left tl w-90 t-mini pb2',
-      brandNameClass: 't-body c-on-base',
     }
+  )
 
-    const priceClasses = {
-      containerClass: classNames('flex flex-column items-end nr1 h1', {
-        [`${productSummary.priceContainer} pv5`]: !showBorders,
-      }),
-      sellingPriceClass: 'dib ph2 t-body t-heading-5-ns',
-    }
-
-    const buyButtonClasses = {
-      containerClass: `${productSummary.buyButtonContainer} pv3 w-100 dn`,
-    }
-
-    return (
-      <section
-        className={constainerClasses}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      >
-        <article className={summaryClasses}>
-          <Link
-            className={`${productSummary.clearLink} flex`}
-            page={'store.product'}
-            params={{ slug: path(['linkText'], product) }}
-            onClick={actionOnClick}
-          >
-            <div className={`${productSummary.imageContainer} db w-30`}>
-              {path(['sku', 'image', 'imageUrl'], product)
-                ? <ProductImage {...imageProps} />
-                : <ImageLoader />}
-            </div>
-            <div className={`${productSummary.information} w-70 pb2 pl3 pr3`}>
-              <ProductSummaryName {...nameProps} {...nameClasses} />
-              <AttachmentList product={product} />
-              <div className="mt3 nr2">
-                <div className="flex justify-end nr4 mb2">
-                  <ProductQuantityStepper
-                    product={product}
-                    onUpdateItemsState={handleItemsStateUpdate}
-                  />
-                </div>
-                <ProductSummaryPrice {...priceProps} {...priceClasses} />
-              </div>
-            </div>
-          </Link>
-          <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
-        </article>
-      </section>
-    )
+  const nameClasses = {
+    containerClass: 'flex items-start justify-left tl w-90 t-mini pb2',
+    brandNameClass: 't-body c-on-base',
   }
+
+  const priceClasses = {
+    containerClass: classNames('flex flex-column items-end nr1 h1', {
+      [`${productSummary.priceContainer} pv5`]: !showBorders,
+    }),
+    sellingPriceClass: 'dib ph2 t-body t-heading-5-ns',
+  }
+
+  const buyButtonClasses = {
+    containerClass: `${productSummary.buyButtonContainer} pv3 w-100 dn`,
+  }
+
+  return (
+    <section
+      className={containerClasses}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <article className={summaryClasses}>
+        <Link
+          className={`${productSummary.clearLink} flex`}
+          page={'store.product'}
+          params={{ slug: path(['linkText'], product) }}
+          onClick={actionOnClick}
+        >
+          <div className={`${productSummary.imageContainer} db w-30`}>
+            {path(['sku', 'image', 'imageUrl'], product) ? (
+              <ProductImage {...imageProps} />
+            ) : (
+              <ImageLoader />
+            )}
+          </div>
+          <div className={`${productSummary.information} w-70 pb2 pl3 pr3`}>
+            <ProductSummaryName {...nameProps} {...nameClasses} />
+            <AttachmentList product={product} />
+            <div className="mt3 nr2">
+              <div className="flex justify-end nr4 mb2">
+                <ProductQuantityStepper
+                  product={product}
+                  onUpdateItemsState={handleItemsStateUpdate}
+                />
+              </div>
+              <ProductSummaryPrice {...priceProps} {...priceClasses} />
+            </div>
+          </div>
+        </Link>
+        <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
+      </article>
+    </section>
+  )
 }
 
 export default ProductSummaryInline

--- a/react/components/ProductSummaryInlinePrice.js
+++ b/react/components/ProductSummaryInlinePrice.js
@@ -34,14 +34,9 @@ class ProductSummaryInline extends Component {
       'overflow-hidden br3 h-100 w-100'
     )
 
-    const summaryClasses = classNames(
-      `${productSummary.element} ${
-        productSummary.clearLink
-      } pointer ph2 pt3 pb4 flex flex-column`,
-      {
-        'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
-      }
-    )
+    const summaryClasses = classNames(`${productSummary.element} pointer ph2 pt3 pb4 flex flex-column`, {
+      'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
+    })
 
     const nameClasses = {
       containerClass: 'flex items-start justify-left tl w-90 t-mini pb2',
@@ -49,14 +44,14 @@ class ProductSummaryInline extends Component {
     }
 
     const priceClasses = {
-      containerClass: classNames('flex flex-column nr1', {
-        [`${productSummary.priceContainer}`]: !showBorders,
+      containerClass: classNames('flex flex-column items-end nr1 h1', {
+        [`${productSummary.priceContainer} pv5`]: !showBorders,
       }),
       sellingPriceClass: 'dib ph2 t-body t-heading-5-ns',
     }
 
     const buyButtonClasses = {
-      containerClass: `${productSummary.buyButtonContainer} pv3 w-100`,
+      containerClass: `${productSummary.buyButtonContainer} pv3 w-100 dn`,
     }
 
     return (
@@ -65,35 +60,34 @@ class ProductSummaryInline extends Component {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <Link
-          className={summaryClasses}
-          page={'store.product'}
-          params={{ slug: path(['linkText'], product) }}
-          onClick={actionOnClick}
-        >
-          <article className="flex">
+        <article className={summaryClasses}>
+          <Link
+            className={`${productSummary.clearLink} flex`}
+            page={'store.product'}
+            params={{ slug: path(['linkText'], product) }}
+            onClick={actionOnClick}
+          >
             <div className={`${productSummary.imageContainer} db w-30`}>
-              {path(['sku', 'image', 'imageUrl'], product) ? (
-                <ProductImage {...imageProps} />
-              ) : (
-                <ImageLoader />
-              )}
+              {path(['sku', 'image', 'imageUrl'], product)
+                ? <ProductImage {...imageProps} />
+                : <ImageLoader />}
             </div>
             <div className={`${productSummary.information} w-70 pb2 pl3 pr3`}>
               <ProductSummaryName {...nameProps} {...nameClasses} />
               <AttachmentList product={product} />
-              <div className="nr2">
+              <div className="mt3 nr2">
+                <div className="flex justify-end nr4 mb2">
+                  <ProductQuantityStepper
+                    product={product}
+                    onUpdateItemsState={handleItemsStateUpdate}
+                  />
+                </div>
                 <ProductSummaryPrice {...priceProps} {...priceClasses} />
               </div>
-              <div className="flex">
-                <ProductSummaryBuyButton
-                  {...buyButtonProps}
-                  {...buyButtonClasses}
-                />
-              </div>
             </div>
-          </article>
-        </Link>
+          </Link>
+          <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />
+        </article>
       </section>
     )
   }

--- a/react/index.js
+++ b/react/index.js
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { withRuntimeContext } from 'vtex.render-runtime'
-import {
-  ProductName,
-  ProductPrice,
-} from 'vtex.store-components'
+import { ProductName, ProductPrice } from 'vtex.store-components'
 
 import ProductSummaryNormal from './components/ProductSummaryNormal'
 import ProductSummarySmall from './components/ProductSummarySmall'
 import ProductSummaryInline from './components/ProductSummaryInline'
+import ProductSummaryInlinePrice from './components/ProductSummaryInlinePrice'
 import displayButtonTypes, {
   getDisplayButtonNames,
   getDisplayButtonValues,
@@ -16,9 +14,10 @@ import displayButtonTypes, {
 import { productShape } from './utils/propTypes'
 
 const DISPLAY_MODE_MAP = {
-  'normal': ProductSummaryNormal,
-  'small': ProductSummarySmall,
-  'inline': ProductSummaryInline,
+  normal: ProductSummaryNormal,
+  small: ProductSummarySmall,
+  inline: ProductSummaryInline,
+  inlinePrice: ProductSummaryInlinePrice,
 }
 
 /**
@@ -64,11 +63,7 @@ class ProductSummary extends Component {
       }),
     }),
     /** Display mode of the summary used in the search result */
-    displayMode: PropTypes.oneOf([
-      'normal',
-      'small',
-      'inline',
-    ]),
+    displayMode: PropTypes.oneOf(['normal', 'small', 'inline', 'inlinePrice']),
     /** Function that is executed when a product is clicked */
     actionOnClick: PropTypes.func,
   }
@@ -104,7 +99,8 @@ class ProductSummary extends Component {
     this.setState({ isHovering: true })
   }
 
-  handleItemsStateUpdate = isLoading => this.setState({ isUpdatingItems: isLoading })
+  handleItemsStateUpdate = isLoading =>
+    this.setState({ isUpdatingItems: isLoading })
 
   render() {
     const {
@@ -148,7 +144,8 @@ class ProductSummary extends Component {
       isHovering: this.state.isHovering,
     }
 
-    const ProductSummaryComponent = DISPLAY_MODE_MAP[displayMode] || ProductSummaryNormal
+    const ProductSummaryComponent =
+      DISPLAY_MODE_MAP[displayMode] || ProductSummaryNormal
     return (
       <ProductSummaryComponent
         product={product}

--- a/react/productSummary.css
+++ b/react/productSummary.css
@@ -1,19 +1,32 @@
-.imageContainer {}
-.container {}
-.containerSmall {}
-.containerInline {}
-.information {}
-.element {}
-.image {}
-.buyButtonContainer {}
-.buyButton {}
-.description {}
+.imageContainer {
+}
+.container {
+}
+.containerSmall {
+}
+.containerInline {
+}
+.containerInlinePrice {
+}
+.information {
+}
+.element {
+}
+.image {
+}
+.buyButtonContainer {
+}
+.buyButton {
+}
+.description {
+}
 
 .isHidden {
   visibility: hidden;
 }
 
-.containerNormal {}
+.containerNormal {
+}
 
 .clearLink {
   text-decoration: inherit;
@@ -25,10 +38,14 @@
   background: center / contain no-repeat;
 }
 
-.nameContainer {}
+.nameContainer {
+}
 
-.priceContainer {}
+.priceContainer {
+}
 
-.attachmentListContainer {}
+.attachmentListContainer {
+}
 
-.attachmentItemContainer {}
+.attachmentItemContainer {
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new product summary type, "inlinePrice".

#### What problem is this solving?
The same product summary inline was been using on the minicart and in the gallery.

It was created a new product summary, specific for the minicart. This way the minicart has one type of product summary and the minicart another.

#### How should this be manually tested?
[Access this workspace](https://theoo--storecomponents.myvtex.com)

#### Screenshots

Before:
![image](https://user-images.githubusercontent.com/5597778/54223069-7bf6b780-44d5-11e9-831b-f2aa9472e440.png)

After:
![image](https://user-images.githubusercontent.com/5597778/54223099-8a44d380-44d5-11e9-93ad-842ff6700e99.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
