### PR TITLE
Display price breaks in product summary section

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -15,5 +15,6 @@
   "editor.productSummary.quantity-error": "editor.productSummary.quantity-error",
   "editor.productSummary.unit": "editor.productSummary.unit",
   "editor.productSummary.attachmentName": "editor.productSummary.attachmentName",
-  "productSummary.missingOptionName": "String displayed when the assembly option was removed by user"
+  "productSummary.missingOptionName": "String displayed when the assembly option was removed by user",
+  "editor.productSummary.showFixedPrices.title": "editor.productSummary.showFixedPrices.title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,5 +15,6 @@
   "editor.productSummary.unit": "Unit",
   "editor.productSummary.attachmentName": "{sign} {quantity}x {name}",
   "editor.productSummary.displayBuyButton.option.hover": "Show on hover (web)",
-  "productSummary.missingOptionName": "No {name}"
+  "productSummary.missingOptionName": "No {name}",
+  "editor.productSummary.showFixedPrices.title": "Show fixed prices"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -15,5 +15,6 @@
   "editor.productSummary.unit": "Unidad",
   "editor.productSummary.attachmentName": "{sign} {quantity}x {name}",
   "editor.productSummary.displayBuyButton.option.hover": "Mostrar al pasar el ratón (web)",
-  "productSummary.missingOptionName": "Sin {name}"
+  "productSummary.missingOptionName": "Sin {name}",
+  "editor.productSummary.showFixedPrices.title": "Show fixed prices"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -15,5 +15,6 @@
   "editor.productSummary.unit": "Unidade",
   "editor.productSummary.attachmentName": "{sign} {quantity}x {name}",
   "editor.productSummary.displayBuyButton.option.hover": "Mostrar ao passar o mouse (web)",
-  "productSummary.missingOptionName": "Sem {name}"
+  "productSummary.missingOptionName": "Sem {name}",
+  "editor.productSummary.showFixedPrices.title": "Show fixed prices"
 }

--- a/react/components/ProductSummaryNormal.js
+++ b/react/components/ProductSummaryNormal.js
@@ -10,7 +10,7 @@ import ProductSummaryBuyButton from './ProductSummaryBuyButton'
 import ProductSummaryPrice from './ProductSummaryPrice'
 import ProductSummaryName from './ProductSummaryName'
 import ProductSummaryDescription from './ProductSummaryDescription'
-
+import FixedPrices from 'vtex.store-components/FixedPrices'
 import productSummary from '../productSummary.css'
 
 class ProductSummaryNormal extends Component {
@@ -26,6 +26,7 @@ class ProductSummaryNormal extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      fixedPriceProps,
     } = this.props
 
     const containerClasses = classNames(
@@ -84,9 +85,13 @@ class ProductSummaryNormal extends Component {
                   descriptionClasses={descriptionClasses}
                 />
               }
-              <div>
-                <ProductSummaryPrice {...priceProps} {...priceClasses} />
-              </div>
+              {
+                fixedPriceProps.showFixedPrices ? (<div>
+                  <FixedPrices {...fixedPriceProps} />
+                </div>) : (<div>
+                  <ProductSummaryPrice {...priceProps} {...priceClasses} />
+                </div>)
+              }
             </div>
           </article>
           <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />

--- a/react/components/ProductSummarySmall.js
+++ b/react/components/ProductSummarySmall.js
@@ -24,6 +24,7 @@ class ProductSummarySmall extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      fixedPriceProps,
     } = this.props
 
     const containerClasses = classNames(
@@ -73,9 +74,13 @@ class ProductSummarySmall extends Component {
             <div className={productSummary.information}>
               <ProductSummaryName {...nameProps} {...nameClasses} />
               <AttachmentList product={product} />
-              <div>
-                <ProductSummaryPrice {...priceProps} {...priceClasses} />
-              </div>
+              {
+                fixedPriceProps.showFixedPrices ? (<div>
+                  <FixedPrices {...fixedPriceProps} />
+                </div>) : (<div>
+                  <ProductSummaryPrice {...priceProps} {...priceClasses} />
+                </div>)
+              }
             </div>
           </article>
           <ProductSummaryBuyButton {...buyButtonProps} {...buyButtonClasses} />

--- a/react/index.js
+++ b/react/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import { path } from 'ramda'
 import { withRuntimeContext } from 'vtex.render-runtime'
 import { ProductName, ProductPrice } from 'vtex.store-components'
 
@@ -66,6 +67,8 @@ class ProductSummary extends Component {
     displayMode: PropTypes.oneOf(['normal', 'small', 'inline', 'inlinePrice']),
     /** Function that is executed when a product is clicked */
     actionOnClick: PropTypes.func,
+    /** Show hide displaying fixed prices instead of normal pricing */
+    showFixedPrices: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -84,6 +87,7 @@ class ProductSummary extends Component {
     },
     displayMode: 'normal',
     showBorders: false,
+    showFixedPrices: false,
   }
 
   state = {
@@ -121,7 +125,10 @@ class ProductSummary extends Component {
       showInstallments,
       labelSellingPrice,
       name: showFieldsProps,
+      showFixedPrices,
     } = this.props
+
+    const fixedPrices = path(['sku', 'seller', 'fixedPrices'], product)
 
     const imageProps = { product, showBadge, badgeText, showCollections }
     const nameProps = { product, showFieldsProps }
@@ -144,6 +151,11 @@ class ProductSummary extends Component {
       isHovering: this.state.isHovering,
     }
 
+    const fixedPriceProps = {
+      showFixedPrices,
+      fixedPriceList: fixedPrices,
+    }
+
     const ProductSummaryComponent =
       DISPLAY_MODE_MAP[displayMode] || ProductSummaryNormal
     return (
@@ -159,6 +171,7 @@ class ProductSummary extends Component {
         nameProps={nameProps}
         priceProps={priceProps}
         buyButtonProps={buyButtonProps}
+        fixedPriceProps={fixedPriceProps}
       />
     )
   }
@@ -204,6 +217,12 @@ const defaultSchema = {
       title: 'editor.productSummary.showCollections.title',
       default: false,
       isLayout: true,
+    },
+    showFieldsProps: {
+      type: 'boolean',
+      title: 'editor.productSummary.showFixedPrices.title',
+      default: false,
+      isLayout: false,
     },
     ...ProductPrice.schema.properties,
   },

--- a/react/index.js
+++ b/react/index.js
@@ -218,7 +218,7 @@ const defaultSchema = {
       default: false,
       isLayout: true,
     },
-    showFieldsProps: {
+    showFixedPrices: {
       type: 'boolean',
       title: 'editor.productSummary.showFixedPrices.title',
       default: false,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prices can be changed with the quantity buying, so we should have option to show price breaks instead. 

#### What problem is this solving?
Showing the price breaks of the product instead of list price

#### How should this be manually tested?
There are 3 PRs are related to this PR
1. [store-graphql](https://github.com/vtex-apps/store-graphql/pull/244)
2. [store-component](https://github.com/vtex-apps/store-components/pull/380)
3. [shelf](https://github.com/vtex-apps/shelf/pull/119)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ x ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
