### PR TITLE
remove product shapes assembly options prop types warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.14.5] - 2019-04-01
 ### Fixed
 - Product shape prop-types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix product shape prop types.
+- Product shape prop-types.
 
 ## [2.14.4] - 2019-04-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix product shape prop types.
 
 ## [2.14.4] - 2019-04-01
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/utils/propTypes.js
+++ b/react/utils/propTypes.js
@@ -1,6 +1,23 @@
 import PropTypes from 'prop-types'
 import { CHOICE_TYPES } from './attachmentHelper'
 
+export const addedOptionShape = PropTypes.shape({
+  item: PropTypes.shape({ 
+    name: PropTypes.string.isRequired, 
+    sellingPrice: PropTypes.number.isRequired,
+    quantity: PropTypes.number.isRequired,
+  }),
+  normalizedQuantity: PropTypes.number,
+  extraQuantity: PropTypes.number,
+  choiceType: PropTypes.oneOf([CHOICE_TYPES.SINGLE, CHOICE_TYPES.MULTIPLE, CHOICE_TYPES.TOGGLE]).isRequired,
+})
+
+export const removedOptionShape = PropTypes.shape({
+  removedQuantity: PropTypes.number.isRequired,
+  initialQuantity: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+})
+
 export const productShape = PropTypes.shape({
   /** Product's link text */
   linkText: PropTypes.string.isRequired,
@@ -61,21 +78,4 @@ export const productShape = PropTypes.shape({
   }),
   /** Quantity of item in Minicart */
   quantity: PropTypes.number,
-})
-
-export const addedOptionShape = PropTypes.shape({
-  item: PropTypes.shape({ 
-    name: PropTypes.string.isRequired, 
-    sellingPrice: PropTypes.number.isRequired,
-    quantity: PropTypes.number.isRequired,
-  }),
-  normalizedQuantity: PropTypes.number,
-  extraQuantity: PropTypes.number,
-  choiceType: PropTypes.oneOf([CHOICE_TYPES.SINGLE, CHOICE_TYPES.MULTIPLE, CHOICE_TYPES.TOGGLE]).isRequired,
-})
-
-export const removedOptionShape = PropTypes.shape({
-  removedQuantity: PropTypes.number.isRequired,
-  initialQuantity: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
 })


### PR DESCRIPTION
A lot of warnings were popping up. Apparently, it happened because some prop shapes were defined after they were used.

source: https://stackoverflow.com/questions/41761135/passing-proptypes-shape-to-proptypes-arrayof-in-react

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
