### PR TITLE
Allow 'product-rating-inline' in 'product-summary.unstable--flex'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Allow `product-rating-inline` in `product-summary.unstable--flex`.
+
 ## [2.17.0] - 2019-04-24
 ### Changed
 - Scope Messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.18.0] - 2019-04-25
+
 ### Added
 - Allow `product-rating-inline` in `product-summary.unstable--flex`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "vtex.store-components": "3.x",
     "vtex.store-resources": "0.x",
+    "vtex.product-review-interfaces": "1.x",
     "vtex.styleguide": "9.x"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -12,7 +12,8 @@
       "product-summary-image",
       "product-summary-name",
       "product-summary-price",
-      "product-summary-space"
+      "product-summary-space",
+      "product-rating-inline"
     ],
     "component": "ProductSummaryCustom",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow 'product-rating-inline' in 'product-summary.unstable--flex'

#### What problem is this solving?
Make it possible for a review app to be installed in the store.

#### How should this be manually tested?

Available in the workspace: https://breno--storecomponents.myvtexdev.com

#### Screenshots or example usage

See https://github.com/vtex-apps/store/pull/219

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
