### PR TITLE
Fix product image product evaluation (console errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `ProductImage` product evaluation.
 
 ## [2.19.1] - 2019-04-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.19.2] - 2019-04-30
 ### Fixed
 - Fix `ProductImage` product evaluation.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/legacy/components/ProductImage.js
+++ b/react/legacy/components/ProductImage.js
@@ -39,6 +39,10 @@ const ProductImage = ({
   showCollections,
   displayMode,
 }) => {
+  if (!path(['sku', 'image', 'imageUrl'], product)) {
+    return <ImagePlaceholder />
+  }
+
   const {
     productClusters,
     productName: name,
@@ -46,10 +50,6 @@ const ProductImage = ({
       image: { imageUrl },
     },
   } = product
-
-  if (!path(['sku', 'image', 'imageUrl'], product)) {
-    return <ImagePlaceholder />
-  }
 
   const imageClassName = classNames({
     [productSummary.imageNormal]: displayMode !== 'inline',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix console errors thrown by the ProductImage component.

#### What problem is this solving?

Product was evaluated before the placeholder logic, so when the product comes null, we got an error.

#### How should this be manually tested?

[Workspace](https://summary--storecomponents.myvtex.com/vintage-camera/p)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
