### PR TITLE
Add labelListPrice prop in ProductSummaryPrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.21.0] - 2019-05-21
 ### Fixed
 - Include `labelListPrice` prop in `productSummaryPrice`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Include `labelListPrice` prop in `productSummaryPrice`.
 
 ## [2.20.3] - 2019-05-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Through the Storefront, you can change the product-summary's behavior and interf
 | `showBadge`         | `Boolean` | Set the discount badge's visibility                                                         |
 | `showDescription`   | `Boolean` | Set product's description visibility                                                        |
 | `labelSellingPrice` | `String`  | Text of selling price's label                                                               |
+| `labelListPrice`    | `String`  | Text of list price's label                                                                  |
 | `badgeText`         | `String`  | Text shown on badge                                                                         |
 | `buyButtonText`     | `String`  | Custom buy button text                                                                      |
 | `displayBuyButton`  | `Enum`    | Set display mode of buy button (displayButtonAlways, displayButtonHover, displayButtonNone) |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.20.3",
+  "version": "2.21.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductSummaryPrice/ProductSummaryPrice.js
+++ b/react/components/ProductSummaryPrice/ProductSummaryPrice.js
@@ -14,6 +14,7 @@ const ProductSummaryPrice = ({
   showLabels,
   showInstallments,
   labelSellingPrice,
+  labelListPrice,
   showBorders,
 }) => {
   const { product, isLoading } = useContext(ProductSummaryContext)
@@ -58,6 +59,7 @@ const ProductSummaryPrice = ({
           showLabels={showLabels}
           showInstallments={showInstallments}
           labelSellingPrice={labelSellingPrice}
+          labelListPrice={labelListPrice}
         />
       )}
     </div>
@@ -73,6 +75,8 @@ ProductSummaryPrice.propTypes = {
   showInstallments: PropTypes.bool,
   /** Text of selling Price's label */
   labelSellingPrice: PropTypes.string,
+  /** Text of list Price's label */
+  labelListPrice: PropTypes.string,
   /** Set installments' visibility */
   showBorders: PropTypes.bool,
 }
@@ -82,6 +86,7 @@ ProductSummaryPrice.defaultProps = {
   showInstallments: true,
   showLabels: true,
   labelSellingPrice: '',
+  labelListPrice: '',
   showBorders: false,
 }
 
@@ -112,6 +117,11 @@ ProductSummaryPrice.getSchema = () => {
       labelSellingPrice: {
         type: 'string',
         title: 'admin/editor.productSummary.labelSellingPrice.title',
+        isLayout: false,
+      },
+      labelListPrice: {
+        type: 'string',
+        title: 'admin/editor.productSummary.labelListPrice.title',
         isLayout: false,
       },
       showBorders: {

--- a/react/components/ProductSummaryPrice/README.md
+++ b/react/components/ProductSummaryPrice/README.md
@@ -39,6 +39,7 @@ Through the Storefront, you can change the `ProductSummaryPrice`'s behavior and 
 | `showInstallments`  | `Boolean` | Set installments' visibility     | `true`        |
 | `showLabels`        | `Boolean` | Set pricing labels' visibility   | `true`        |
 | `labelSellingPrice` | `String`  | Text of selling price's label    |               |
+| `labelListPrice`    | `String`  | Text of list price's label       |               |   
 | `showBorders`       | `Boolean` | Set product's borders visibility | `false`       |
 
 ### Styles API

--- a/react/legacy/components/ProductSummaryPrice.js
+++ b/react/legacy/components/ProductSummaryPrice.js
@@ -12,6 +12,7 @@ const ProductSummaryPrice = ({
   showLabels,
   showInstallments,
   labelSellingPrice,
+  labelListPrice,
   isLoading,
   containerClass,
 }) => {
@@ -49,6 +50,7 @@ const ProductSummaryPrice = ({
           showLabels={showLabels}
           showInstallments={showInstallments}
           labelSellingPrice={labelSellingPrice}
+          labelListPrice={labelListPrice}
         />
       )}
     </div>
@@ -66,6 +68,8 @@ ProductSummaryPrice.propTypes = {
   showInstallments: PropTypes.bool,
   /** Text of selling Price's label */
   labelSellingPrice: PropTypes.string,
+  /** Text of selling Price's label */
+  labelListPrice: PropTypes.string,
   /** Defines if the loading spinner is shown */
   isLoading: PropTypes.bool,
   /** Styles used in the container div */

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -48,6 +48,8 @@ class ProductSummary extends Component {
     showQuantitySelector: PropTypes.bool,
     /** Text of selling Price's label */
     labelSellingPrice: PropTypes.string,
+    /** Text of list Price's label */
+    labelListPrice: PropTypes.string,
     /** Text shown on badge */
     badgeText: PropTypes.string,
     /** Custom buy button text */
@@ -128,6 +130,7 @@ class ProductSummary extends Component {
       showLabels,
       showInstallments,
       labelSellingPrice,
+      labelListPrice,
       name: showFieldsProps,
       showQuantitySelector,
       priceAlignLeft,
@@ -148,6 +151,7 @@ class ProductSummary extends Component {
       showLabels,
       showInstallments,
       labelSellingPrice,
+      labelListPrice,
       isLoading: this.state.isUpdatingItems,
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add labelListPrice on the `productSummaryPrice` and pass the prop to the `ProductPrice`.

#### What problem is this solving?
Discount price labels should be flexible.

#### How should this be manually tested?
[Workspace](https://imagesize--storecomponents.myvtex.com/?disableUserLand)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
