### PR TITLE
Added missing interface to handle Wishlist button when using product-summary.shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Missing interface to handle Wishlist button when using `product-summary.shelf`.
+
+### Fixed
+
+- Add `product-rating-inline` to `product-summary-column`.
+
 ## [2.24.2] - 2019-06-04
 ### Changed
 - Updated `vtex.pixel-manager`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.25.0] - 2019-06-10
+
 ### Added
 
 - Missing interface to handle Wishlist button when using `product-summary.shelf`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.24.2",
+  "version": "2.25.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/ProductSummaryAddToListButton.js
+++ b/react/ProductSummaryAddToListButton.js
@@ -1,0 +1,3 @@
+import ProductSummaryAddToListButton from './components/ProductSummaryAddToListButton/ProductSummaryAddToListButton'
+
+export default ProductSummaryAddToListButton

--- a/react/components/ProductSummaryAddToListButton/ProductSummaryAddToListButton.js
+++ b/react/components/ProductSummaryAddToListButton/ProductSummaryAddToListButton.js
@@ -1,0 +1,33 @@
+import React, { useMemo, useContext } from 'react'
+import { ExtensionPoint } from 'vtex.render-runtime'
+import { path } from 'ramda'
+import ProductSummaryContext from '../ProductSummaryContext'
+import productSummary from '../../productSummary.css'
+
+const getSkuId = path(['sku', 'itemId'])
+const getProductId = path(['productId'])
+
+// This avoids triggering the link to the product page
+const captureClick = e => {
+  e.preventDefault()
+  e.stopPropagation()
+}
+
+function ProductSummaryAddToListButton({ product }) {
+  const productContext = useContext(ProductSummaryContext)
+
+  const skuId = getSkuId(productContext.product)
+  const productId = getProductId(productContext.product)
+
+  const productProp = useMemo(() => ({
+    skuId, productId, quantity: 1
+  }), [skuId, productId])
+
+  return (
+    <div className={`${productSummary.addToListBtn} absolute z-1`} onClick={captureClick}>
+      <ExtensionPoint id="addon-summary-btn" product={productProp} />
+    </div>
+  )
+}
+
+export default ProductSummaryAddToListButton

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -16,6 +16,7 @@
       "product-summary-name",
       "product-summary-price",
       "product-summary-space",
+      "product-summary-add-to-list-button",
       "product-rating-inline"
     ],
     "component": "ProductSummaryCustom",
@@ -29,7 +30,9 @@
       "product-summary-image",
       "product-summary-name",
       "product-summary-price",
-      "product-summary-space"
+      "product-summary-space",
+      "product-summary-add-to-list-button",
+      "product-rating-inline"
     ],
     "component": "Column",
     "composition": "children"
@@ -106,6 +109,12 @@
         }
       }
     }
+  },
+  "product-summary-add-to-list-button": {
+    "component": "ProductSummaryAddToListButton",
+    "allowed": [
+      "addon-summary-btn"
+    ]
   },
   "addon-summary-btn": {
     "component": "*"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Handle wishlist in destructured version of product-summary.

#### What problem is this solving?

Wishlist would appear at the bottom of the product-summary.

#### How should this be manually tested?

https://breno--storecomponents.myvtexdev.com/decoration

#### Screenshots or example usage

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/59204792-c096fb00-8b77-11e9-92f9-d14798d52626.png) | ![image](https://user-images.githubusercontent.com/284515/59204874-f6d47a80-8b77-11e9-94ed-20e04b78bdc1.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
