### PR TITLE
Add prop to show loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Prop to show loading state when the product is locally persisted.
+- Prop to show muted state.
 
 ## [2.28.0] - 2019-07-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop to show loading state when the product is locally persisted.
 
 ## [2.28.0] - 2019-07-08
 ### Changed

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import { Link } from 'vtex.render-runtime'
+import { Spinner } from 'vtex.styleguide'
 
 import AttachmentList from './AttachmentList'
 import ProductImage from './ProductImage'
@@ -8,9 +9,9 @@ import ProductQuantityStepper from './ProductQuantityStepper'
 import ProductSummaryPrice from './ProductSummaryPrice'
 import ProductSummaryName from './ProductSummaryName'
 
-import productSummary from '../../productSummary.css'
+import styles from '../../productSummary.css'
 
-const ProductSummaryInline = ({
+const ProductSummaryInlinePrice = ({
   product,
   showBorders,
   handleMouseEnter,
@@ -22,32 +23,44 @@ const ProductSummaryInline = ({
   priceProps,
   showQuantitySelector,
   priceAlignLeft,
+  isPartial,
 }) => {
   const containerClasses = classNames(
-    productSummary.container,
-    productSummary.containerInline,
+    styles.container,
+    styles.containerInline,
     'overflow-hidden br3 h-100 w-100'
   )
 
   const summaryClasses = classNames(
-    `${productSummary.element} pointer ph2 pt3 pb4 flex flex-column h-100`,
+    `${styles.element} pointer ph2 pt3 pb4 flex flex-column h-100`,
     {
       'bb b--muted-4 mh2 mh3-ns mt2': showBorders,
     }
   )
 
   const nameClasses = {
-    containerClass: 'flex items-start justify-left tl w-90 t-mini pb2',
-    brandNameClass: 't-body c-on-base',
+    containerClass: classNames(
+      'flex items-start justify-left tl w-90 t-mini pb2',
+      { 'c-muted-1': isPartial }
+    ),
+    brandNameClass: classNames('t-body', {
+      'c-muted-1': isPartial,
+      'c-on-base': !isPartial,
+    }),
+    skuNameClass: classNames('t-small', {
+      'c-muted-2': isPartial,
+    }),
   }
 
   const priceClasses = {
     containerClass: classNames('flex flex-column nr1 h1', {
       'items-start': priceAlignLeft,
       'items-end': !priceAlignLeft,
-      [`${productSummary.priceContainer} pv5`]: !showBorders,
+      [`${styles.priceContainer} pv5`]: !showBorders,
     }),
-    sellingPriceClass: 'dib ph2 t-body t-heading-5-ns',
+    sellingPriceClass: classNames('dib ph2 t-body t-heading-5-ns', {
+      'c-muted-1': isPartial,
+    }),
   }
 
   return (
@@ -58,23 +71,31 @@ const ProductSummaryInline = ({
     >
       <article className={summaryClasses}>
         <Link
-          className={`${productSummary.clearLink} flex h-100`}
-          page={'store.product'}
+          className={`${styles.clearLink} flex h-100`}
+          page="store.product"
           params={{
             slug: product && product.linkText,
             id: product && product.productId,
           }}
           onClick={actionOnClick}
         >
-          <div className={`${productSummary.imageContainer} db h-100`}>
+          <div className={`${styles.imageContainer} db h-100 relative`}>
             <ProductImage {...imageProps} />
+
+            {isPartial && (
+              <div className="absolute left-0 top-0 w-100 h-100 flex items-center justify-center">
+                <Spinner />
+              </div>
+            )}
           </div>
-          <div className={`${productSummary.information} w-70 pb2 pl3 pr3`}>
+          <div className={`${styles.information} w-70 pb2 pl3 pr3`}>
             <ProductSummaryName {...nameProps} {...nameClasses} />
             <AttachmentList product={product} />
             <div className="mt3 nr2">
               <div
-                className={`flex justify-end nr4 mb2 ${productSummary.quantityStepperContainer}`}
+                className={`flex justify-end nr4 mb2 ${
+                  styles.quantityStepperContainer
+                }`}
               >
                 {showQuantitySelector && (
                   <ProductQuantityStepper
@@ -92,4 +113,4 @@ const ProductSummaryInline = ({
   )
 }
 
-export default ProductSummaryInline
+export default ProductSummaryInlinePrice

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
 import { Link } from 'vtex.render-runtime'
-import { Spinner } from 'vtex.styleguide'
 
 import AttachmentList from './AttachmentList'
 import ProductImage from './ProductImage'
@@ -23,7 +22,7 @@ const ProductSummaryInlinePrice = ({
   priceProps,
   showQuantitySelector,
   priceAlignLeft,
-  isPartial,
+  muted,
 }) => {
   const containerClasses = classNames(
     styles.container,
@@ -41,14 +40,14 @@ const ProductSummaryInlinePrice = ({
   const nameClasses = {
     containerClass: classNames(
       'flex items-start justify-left tl w-90 t-mini pb2',
-      { 'c-muted-1': isPartial }
+      { 'c-muted-1': muted }
     ),
     brandNameClass: classNames('t-body', {
-      'c-muted-1': isPartial,
-      'c-on-base': !isPartial,
+      'c-muted-1': muted,
+      'c-on-base': !muted,
     }),
     skuNameClass: classNames('t-small', {
-      'c-muted-2': isPartial,
+      'c-muted-2': muted,
     }),
   }
 
@@ -59,7 +58,7 @@ const ProductSummaryInlinePrice = ({
       [`${styles.priceContainer} pv5`]: !showBorders,
     }),
     sellingPriceClass: classNames('dib ph2 t-body t-heading-5-ns', {
-      'c-muted-1': isPartial,
+      'c-muted-1': muted,
     }),
   }
 
@@ -79,14 +78,8 @@ const ProductSummaryInlinePrice = ({
           }}
           onClick={actionOnClick}
         >
-          <div className={`${styles.imageContainer} db h-100 relative`}>
+          <div className={`${styles.imageContainer} db h-100`}>
             <ProductImage {...imageProps} />
-
-            {isPartial && (
-              <div className="absolute left-0 top-0 w-100 h-100 flex items-center justify-center">
-                <Spinner />
-              </div>
-            )}
           </div>
           <div className={`${styles.information} w-70 pb2 pl3 pr3`}>
             <ProductSummaryName {...nameProps} {...nameClasses} />

--- a/react/legacy/components/ProductSummaryName.js
+++ b/react/legacy/components/ProductSummaryName.js
@@ -10,6 +10,7 @@ const ProductSummaryName = ({
   showFieldsProps,
   containerClass,
   brandNameClass,
+  skuNameClass,
 }) => {
   const productName = path(['productName'], product)
   const skuName = path(['sku', 'name'], product)
@@ -20,7 +21,7 @@ const ProductSummaryName = ({
       <ProductName
         className="overflow-hidden c-on-base"
         brandNameClass={brandNameClass}
-        skuNameClass="t-small"
+        skuNameClass={skuNameClass}
         loaderClass="pt5 overflow-hidden"
         name={productName}
         skuName={skuName}

--- a/react/legacy/components/ProductSummaryPrice.js
+++ b/react/legacy/components/ProductSummaryPrice.js
@@ -15,6 +15,7 @@ const ProductSummaryPrice = ({
   labelListPrice,
   isLoading,
   containerClass,
+  sellingPriceClass,
 }) => {
   const commertialOffer = path(['sku', 'seller', 'commertialOffer'], product)
 
@@ -38,7 +39,7 @@ const ProductSummaryPrice = ({
           listPriceClass="dib ph2 strike t-small-ns t-mini"
           sellingPriceContainerClass="pt1 pb3 c-on-base"
           sellingPriceLabelClass="dib"
-          sellingPriceClass="dib ph2 t-body t-heading-5-ns"
+          sellingPriceClass={sellingPriceClass}
           savingsContainerClass="t-small-ns c-muted-2"
           savingsClass="dib"
           interestRateClass="dib pl2"

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -92,7 +92,7 @@ class ProductSummary extends Component {
     },
     displayMode: 'normal',
     showBorders: false,
-    isPartial: false,
+    muted: false,
   }
 
   state = {
@@ -133,7 +133,7 @@ class ProductSummary extends Component {
       nameSchema: showFieldsProps,
       showQuantitySelector,
       priceAlignLeft,
-      isPartial,
+      muted,
     } = this.props
 
     const imageProps = {
@@ -182,7 +182,7 @@ class ProductSummary extends Component {
         buyButtonProps={buyButtonProps}
         showQuantitySelector={showQuantitySelector}
         priceAlignLeft={priceAlignLeft}
-        isPartial={isPartial}
+        muted={muted}
       />
     )
   }

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -59,7 +59,7 @@ class ProductSummary extends Component {
     /** Defines if the collection badges are shown */
     showCollections: PropTypes.bool,
     /** Name schema props */
-    name: PropTypes.object,
+    nameSchema: PropTypes.object,
     /** Runtime context */
     runtime: PropTypes.shape({
       hints: PropTypes.shape({
@@ -85,13 +85,14 @@ class ProductSummary extends Component {
     showDescription: false,
     displayBuyButton: displayButtonTypes.DISPLAY_ALWAYS.value,
     isOneClickBuy: false,
-    name: {
+    nameSchema: {
       showProductReference: false,
       showBrandName: false,
       showSku: false,
     },
     displayMode: 'normal',
     showBorders: false,
+    isPartial: false,
   }
 
   state = {
@@ -129,9 +130,10 @@ class ProductSummary extends Component {
       showInstallments,
       labelSellingPrice,
       labelListPrice,
-      name: showFieldsProps,
+      nameSchema: showFieldsProps,
       showQuantitySelector,
       priceAlignLeft,
+      isPartial,
     } = this.props
 
     const imageProps = {
@@ -164,6 +166,7 @@ class ProductSummary extends Component {
 
     const ProductSummaryComponent =
       DISPLAY_MODE_MAP[displayMode] || ProductSummaryNormal
+
     return (
       <ProductSummaryComponent
         product={product}
@@ -179,6 +182,7 @@ class ProductSummary extends Component {
         buyButtonProps={buyButtonProps}
         showQuantitySelector={showQuantitySelector}
         priceAlignLeft={priceAlignLeft}
+        isPartial={isPartial}
       />
     )
   }
@@ -225,7 +229,7 @@ ProductSummary.getSchema = () => {
     ...defaultSchema,
     properties: {
       ...defaultSchema.properties,
-      name: nameSchema,
+      nameSchema,
     },
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a `isPartial` prop to show a loading state on the product, for when it's only locally persisted in the minicart.

#### What problem is this solving?
Before, we had no visual indication that the item was only locally persisted or not.

#### How should this be manually tested?
[workspace](https://lucas2--storecomponents.myvtex.com/).

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
