### PR TITLE
Remove package.json from .vtexignore

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -2,7 +2,6 @@
 react/node_modules/
 .eslintrc
 .gitignore
-package.json
 README.md
 CHANGELOG.md
 react/**/__tests__/**


### PR DESCRIPTION
#### What is the purpose of this pull request?

#### What problem is this solving?
`.vtexignore` will soon follow `.gitignore` syntax. Since `package.json` means *all files in subfolders called package.json*, this will fail build because `react/package.json` won't be there.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
