### PR TITLE
Adds id to internal routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Uses link with product id instead of `/p` only
 
 ## [2.27.0] - 2019-07-04
 ### Deprecated

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -80,8 +80,7 @@ const ProductSummaryCustom = ({ product, actionOnClick, children }) => {
           page="store.product"
           params={{
             slug: product && product.linkText,
-            // WARNING: this enables links with translatable slugs
-            // id: product && product.productId,
+            id: product && product.productId,
           }}
           onClick={actionOnClick}
         >

--- a/react/legacy/components/ProductSummaryInline.js
+++ b/react/legacy/components/ProductSummaryInline.js
@@ -64,8 +64,7 @@ class ProductSummaryInline extends Component {
           page={'store.product'}
           params={{
             slug: product && product.linkText,
-            // WARNING: this enables links with translatable slugs
-            // id: product && product.productId,
+            id: product && product.productId,
           }}
           onClick={actionOnClick}
         >

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -62,8 +62,7 @@ const ProductSummaryInline = ({
           page={'store.product'}
           params={{
             slug: product && product.linkText,
-            // WARNING: this enables links with translatable slugs
-            // id: product && product.productId,
+            id: product && product.productId,
           }}
           onClick={actionOnClick}
         >


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR rolls back the decision to deprecate internal product routes with ids. This time it's safe to go forward with this decision, since runtime now navigates using canonical routes

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
