### PR TITLE
Use local items update mutation

### DIFF
--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -9,5 +9,15 @@ export function ExtensionPoint(props) {
 }
 
 export function withRuntimeContext(Comp) {
-  return Comp
+  const InjectRuntime = props => {
+    return <Comp {...props} runtime={{ hints: { mobile: false } }} />
+  }
+
+  return InjectRuntime
+}
+
+export const useRuntime = () => {
+  return {
+    hints: { mobile: false },
+  }
 }

--- a/react/legacy/components/ProductQuantityStepper.js
+++ b/react/legacy/components/ProductQuantityStepper.js
@@ -10,13 +10,13 @@ import gql from 'graphql-tag'
 
 import { productShape } from '../../utils/propTypes'
 
-export const UPDATE_ITEMS_MUTATION = gql`
+const UPDATE_ITEMS_MUTATION = gql`
   mutation updateItems($items: [MinicartItem]) {
     updateItems(items: $items) @client
   }
 `
 
-export const UPDATE_LOCAL_ITEMS_MUTATION = gql`
+const UPDATE_LOCAL_ITEMS_MUTATION = gql`
   mutation updateLocalItems($items: [MinicartItem]) {
     updateLocalItems(items: $items) @client
   }

--- a/react/legacy/components/ProductSummaryBuyButton.js
+++ b/react/legacy/components/ProductSummaryBuyButton.js
@@ -3,6 +3,7 @@ import BuyButton from 'vtex.store-components/BuyButton'
 import { equals, path } from 'ramda'
 import classNames from 'classnames'
 import { IOMessage } from 'vtex.native-types'
+import { useRuntime } from 'vtex.render-runtime'
 
 import displayButtonTypes from '../../utils/displayButtonTypes'
 import productSummary from '../../productSummary.css'
@@ -12,12 +13,13 @@ const ProductSummaryBuyButton = ({
   displayBuyButton,
   isOneClickBuy,
   buyButtonText,
-  runtime: {
-    hints: { mobile },
-  },
   isHovering,
   containerClass,
 }) => {
+  const {
+    hints: { mobile },
+  } = useRuntime()
+
   const hoverBuyButton =
     equals(displayBuyButton, displayButtonTypes.DISPLAY_ALWAYS.value) ||
     !equals(displayBuyButton, displayButtonTypes.DISPLAY_ON_HOVER.value) ||

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -23,6 +23,7 @@ const ProductSummaryInlinePrice = ({
   showQuantitySelector,
   priceAlignLeft,
   muted,
+  index,
 }) => {
   const containerClasses = classNames(
     styles.container,
@@ -86,14 +87,13 @@ const ProductSummaryInlinePrice = ({
             <AttachmentList product={product} />
             <div className="mt3 nr2">
               <div
-                className={`flex justify-end nr4 mb2 ${
-                  styles.quantityStepperContainer
-                }`}
+                className={`flex justify-end nr4 mb2 ${styles.quantityStepperContainer}`}
               >
                 {showQuantitySelector && (
                   <ProductQuantityStepper
                     product={product}
                     onUpdateItemsState={handleItemsStateUpdate}
+                    index={index}
                   />
                 )}
               </div>

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-handler-names */
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { withRuntimeContext } from 'vtex.render-runtime'
 import { ProductName, ProductPrice } from 'vtex.store-components'
 
 import ProductSummaryNormal from './components/ProductSummaryNormal'
@@ -60,19 +59,14 @@ class ProductSummary extends Component {
     showCollections: PropTypes.bool,
     /** Name schema props */
     nameSchema: PropTypes.object,
-    /** Runtime context */
-    runtime: PropTypes.shape({
-      hints: PropTypes.shape({
-        /** Indicates if is on a mobile device */
-        mobile: PropTypes.bool,
-      }),
-    }),
     /** Display mode of the summary used in the search result */
     displayMode: PropTypes.oneOf(['normal', 'small', 'inline', 'inlinePrice']),
     /** Function that is executed when a product is clicked */
     actionOnClick: PropTypes.func,
     /** Set the price align to left */
     priceAlignLeft: PropTypes.bool,
+    muted: PropTypes.bool,
+    index: PropTypes.number,
   }
 
   static defaultProps = {
@@ -121,7 +115,6 @@ class ProductSummary extends Component {
       buyButtonText,
       showBorders,
       showDescription,
-      runtime,
       showBadge,
       badgeText,
       showCollections,
@@ -134,6 +127,7 @@ class ProductSummary extends Component {
       showQuantitySelector,
       priceAlignLeft,
       muted,
+      index,
     } = this.props
 
     const imageProps = {
@@ -160,7 +154,6 @@ class ProductSummary extends Component {
       displayBuyButton,
       isOneClickBuy,
       buyButtonText,
-      runtime,
       isHovering: this.state.isHovering,
     }
 
@@ -183,6 +176,7 @@ class ProductSummary extends Component {
         showQuantitySelector={showQuantitySelector}
         priceAlignLeft={priceAlignLeft}
         muted={muted}
+        index={index}
       />
     )
   }
@@ -234,4 +228,4 @@ ProductSummary.getSchema = () => {
   }
 }
 
-export default withRuntimeContext(ProductSummary)
+export default ProductSummary


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the logic to update the items quantity to use a different mutation when the product is a local item only, i.e. doesn't have a `cartIndex` property yet.

#### What problem is this solving?
This is needed so we can avoid mixing logic from updating items that need to be synchronized with the server and local items only.

The scenario would be to update items that were added when the user is offline and were never synchronized with the server before, i.e. the user didn't return online with the item in the cart.

#### How should this be manually tested?
[workspace](https://lucas2--storecomponents.myvtex.com/), add an item when you're offline and update it's quantity.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
