### PR TITLE
Use function provided by BuyButton to normalize its prop

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use private function provided by BuyButton component to normalize its props.
 
 ## [2.29.1] - 2019-07-17
 

--- a/react/__mocks__/vtex.store-components/BuyButton.js
+++ b/react/__mocks__/vtex.store-components/BuyButton.js
@@ -7,4 +7,26 @@ const BuyButton = ({ children }) => {
   return <div className="buy-button-mock">{children}</div>
 }
 
+BuyButton.mapCatalogItemToCart = function mapCatalogItemToCart({
+  selectedQuantity,
+}) {
+  return [
+    {
+      index: 0,
+      quantity: selectedQuantity,
+      detailUrl: '/product-name/p',
+      name: 'Product name',
+      brand: 'Brand',
+      category: 'Category',
+      productRefId: 'REF',
+      seller: 'VTEX',
+      price: 9,
+      listPrice: 10,
+      variant: 'Name',
+      skuId: '1',
+      imageUrl: 'https://foo.com/image.png',
+    },
+  ]
+}
+
 export default BuyButton

--- a/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
@@ -11,6 +11,7 @@ import displayButtonTypes, {
   getDisplayButtonNames,
   getDisplayButtonValues,
 } from '../../utils/displayButtonTypes'
+
 import productSummary from '../../productSummary.css'
 
 const ProductSummaryBuyButton = ({
@@ -46,10 +47,18 @@ const ProductSummaryBuyButton = ({
   const containerClass = `${productSummary.buyButtonContainer} pv3 w-100 db`
 
   // TODO: change ProductSummaryContext to have `selectedSku` field instead of `sku`
-  const quantity =
-    path(['sku', 'seller', 'commertialOffer', 'AvailableQuantity'], product) ||
-    0
-  const isAvailable = quantity > 0
+  const selectedItem = product.sku
+  const selectedSeller = path(['seller'], selectedItem)
+  const isAvailable =
+    selectedSeller &&
+    selectedSeller.commertialOffer &&
+    selectedSeller.commertialOffer.AvailableQuantity > 0
+  const skuItems = BuyButton.mapCatalogItemToCart({
+    product,
+    selectedItem,
+    selectedSeller,
+    selectedQuantity: 1,
+  })
 
   return (
     showBuyButton && (
@@ -57,28 +66,7 @@ const ProductSummaryBuyButton = ({
         <div className={buyButtonClasses}>
           <BuyButton
             available={isAvailable}
-            skuItems={
-              path(['sku', 'itemId'], product) && [
-                {
-                  detailUrl: `/${product.linkText}/p`,
-                  imageUrl: path(['sku', 'image', 'imageUrl'], product),
-                  listPrice: path(
-                    ['sku', 'seller', 'commertialOffer', 'ListPrice'],
-                    product
-                  ),
-                  skuId: path(['sku', 'itemId'], product),
-                  quantity: 1,
-                  seller: path(['sku', 'seller', 'sellerId'], product),
-                  name: product.productName,
-                  price: path(
-                    ['sku', 'seller', 'commertialOffer', 'Price'],
-                    product
-                  ),
-                  variant: product.sku.name,
-                  brand: product.brand,
-                },
-              ]
-            }
+            skuItems={skuItems}
             isOneClickBuy={isOneClickBuy}
           >
             <IOMessage id={buyButtonText} />

--- a/react/legacy/components/ProductSummaryBuyButton.js
+++ b/react/legacy/components/ProductSummaryBuyButton.js
@@ -39,10 +39,19 @@ const ProductSummaryBuyButton = ({
     }
   )
 
-  const quantity =
-    path(['sku', 'seller', 'commertialOffer', 'AvailableQuantity'], product) ||
-    0
-  const isAvailable = quantity > 0
+  // TODO: change ProductSummaryContext to have `selectedSku` field instead of `sku`
+  const selectedItem = product.sku
+  const selectedSeller = path(['seller'], selectedItem)
+  const isAvailable =
+    selectedSeller &&
+    selectedSeller.commertialOffer &&
+    selectedSeller.commertialOffer.AvailableQuantity > 0
+  const skuItems = BuyButton.mapCatalogItemToCart({
+    product,
+    selectedItem,
+    selectedSeller,
+    selectedQuantity: 1,
+  })
 
   return (
     showBuyButton && (
@@ -50,28 +59,7 @@ const ProductSummaryBuyButton = ({
         <div className={buyButtonClasses}>
           <BuyButton
             available={isAvailable}
-            skuItems={
-              path(['sku', 'itemId'], product) && [
-                {
-                  detailUrl: `/${product.linkText}/p`,
-                  imageUrl: path(['sku', 'image', 'imageUrl'], product),
-                  listPrice: path(
-                    ['sku', 'seller', 'commertialOffer', 'ListPrice'],
-                    product
-                  ),
-                  skuId: path(['sku', 'itemId'], product),
-                  quantity: 1,
-                  seller: path(['sku', 'seller', 'sellerId'], product),
-                  name: product.productName,
-                  price: path(
-                    ['sku', 'seller', 'commertialOffer', 'Price'],
-                    product
-                  ),
-                  variant: product.sku.name,
-                  brand: product.brand,
-                },
-              ]
-            }
+            skuItems={skuItems}
             isOneClickBuy={isOneClickBuy}
           >
             <IOMessage id={buyButtonText} />


### PR DESCRIPTION
#### What is the purpose of this pull request?
The logic of mapping the data to be used by BuyButton was being replicated in two ProductBuyButton components. Also if one needed to add or remove something it would need to change the code in 3 different places. This PR centralizes where this mapping is done.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

n/a

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


Depends on https://github.com/vtex-apps/store-components/pull/529