### PR TITLE
Allow product-teaser.summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow product-teaser.summary.
 
 ## [2.30.0] - 2019-07-26
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "vtex.product-summary-context": "0.x",
     "vtex.product-identifier": "0.x",
     "vtex.styleguide": "9.x",
-    "vtex.pixel-manager": "1.x"
+    "vtex.pixel-manager": "1.x",
+    "vtex.product-teaser-interfaces": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -18,7 +18,8 @@
       "product-identifier",
       "product-summary-space",
       "product-summary-add-to-list-button",
-      "product-rating-inline"
+      "product-rating-inline",
+      "product-teaser.summary"
     ],
     "component": "ProductSummaryCustom",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow product-teaser.summary to summary.

#### What problem is this solving?

Integrate with https://docs.affirm.com/Integrate_Affirm/Promotional_Messaging

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/62238092-a4aa1b80-b3a8-11e9-9651-086fd5f2c24c.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
