### PR TITLE
Fix interaction with the quantity input triggering the link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Interaction with the quantity input in the minicart was trigerring the link.
 
 ## [2.32.0] - 2019-08-06
 ### Added

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -87,6 +87,11 @@ const ProductSummaryInlinePrice = ({
             <AttachmentList product={product} />
             <div className="mv3 nr2">
               <div
+                onClick={e => {
+                  e.preventDefault()
+                  // Stop propagation so it doesn't trigger the Link component above
+                  e.stopPropagation()
+                }}
                 className={`flex justify-end nr4 mb2 ${styles.quantityStepperContainer}`}
               >
                 {showQuantitySelector && (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the issue described here https://github.com/vtex-apps/minicart/issues/172

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/classic-shoes/p
Add an item to the cart, click in the quantity input and verify that it doesn't go the product page.

Compare with:
https://storecomponents.myvtex.com/classic-shoes/p

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
