### PR TITLE
Added `ProductSummaryBrand` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `ProductSummaryBrand` component
+
 ## [2.32.2] - 2019-08-09
 ### Fixed
 - Interaction with the quantity input in the minicart was trigerring the link.

--- a/react/ProductSummaryBrand.js
+++ b/react/ProductSummaryBrand.js
@@ -1,0 +1,3 @@
+import ProductSummaryBrand from './components/ProductSummaryBrand/ProductSummaryBrand'
+
+export default ProductSummaryBrand

--- a/react/components/ProductSummaryBrand/ProductSummaryBrand.js
+++ b/react/components/ProductSummaryBrand/ProductSummaryBrand.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ProductBrand } from 'vtex.store-components'
+
+import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
+
+const DISPLAY_MODE = {
+  LOGO: 'logo',
+  TEXT: 'text',
+}
+
+const ProductSummaryBrand = ({
+  displayMode,
+  fallbackToText,
+  height,
+  excludeBrands,
+  logoWithLink,
+}) => {
+  const { product } = useProductSummary()
+  return (
+    <ProductBrand
+      displayMode={displayMode}
+      fallbackToText={fallbackToText}
+      height={height}
+      excludeBrands={excludeBrands}
+      logoWithLink={logoWithLink}
+      brandName={product.brand}
+      brandId={product.brandId}
+    />
+  )
+}
+
+ProductSummaryBrand.propTypes = {
+  /** Whether it should be displayed as a logo or as a text */
+  displayMode: PropTypes.oneOf(Object.values(DISPLAY_MODE)),
+  /** Whether it should display the name of the brand if there is no logo */
+  fallbackToText: PropTypes.bool,
+  /** List of brands that should be hidden, if any */
+  excludeBrands: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
+  /** Height of the logo */
+  height: PropTypes.number,
+  /** If the logo should have a link*/
+  logoWithLink: PropTypes.bool,
+}
+
+export default ProductSummaryBrand

--- a/react/components/ProductSummaryBrand/README.md
+++ b/react/components/ProductSummaryBrand/README.md
@@ -1,0 +1,40 @@
+# Product Summary Name
+
+## Description
+
+`ProductSummaryBrand` is a VTEX Component that renders the product's brand.
+This Component can be imported and used by any VTEX App.
+
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
+
+## Table of Contents
+- [Usage](#usage)
+  - [Blocks API](#blocks-api)
+  - [Configuration](#configuration)
+  - [Styles API](#styles-api)
+
+## Usage
+
+You should follow the usage instruction in the main [README](https://github.com/vtex-apps/product-summary/blob/master/README.md#usage).
+
+Then, add `product-summary-brand` block into your app theme.
+
+### Blocks API
+
+This component has an interface that describes which rules must be implemented by a block when you want to use the `ProductSummaryBrand`.
+
+```json
+  "product-summary-brand": {
+    "component": "ProductSummaryBrand"
+  }
+```
+
+### Configuration
+
+Through the Storefront, you can change the `ProductSummaryBrand`'s behavior and interface. However, you also can make in your theme app.
+
+You can find all options available in [Store Components Product Brand app](https://github.com/vtex-apps/store-components/blob/master/react/components/ProductBrand/README.md).
+
+### Styles API
+
+To change the style of this app, do it in the [Store Components Product Brand app](https://github.com/vtex-apps/store-components/blob/master/react/components/ProductBrand/README.md).

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -19,7 +19,8 @@
       "product-summary-space",
       "product-summary-add-to-list-button",
       "product-rating-inline",
-      "product-teaser.summary"
+      "product-teaser.summary",
+      "product-summary-brand"
     ],
     "component": "ProductSummaryCustom",
     "composition": "children"
@@ -99,6 +100,9 @@
   },
   "product-summary-name": {
     "component": "ProductSummaryName"
+  },
+  "product-summary-brand": {
+    "component": "ProductSummaryBrand"
   },
   "product-summary-price": {
     "component": "ProductSummaryPrice",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible to have a brand in the product summary. Depends on https://github.com/vtex-apps/store-components/pull/555 to work properly

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/63381008-2967d400-c36e-11e9-9fcf-778eedabfbb2.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
