### PR TITLE
Allowed `product-summary-quantity` in the shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `product-summary-quantity` to the shelf's allowed array
 
 ## [2.33.0] - 2019-08-20
-
 ### Added
-
 - `ProductSummaryBrand` component
 
 ## [2.32.2] - 2019-08-09

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "vtex.styleguide": "9.x",
     "vtex.pixel-manager": "1.x",
     "vtex.product-teaser-interfaces": "1.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.product-quantity": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
@@ -23,7 +23,7 @@ const ProductSummaryBuyButton = ({
   },
   isHovering,
 }) => {
-  const { product } = useProductSummary()
+  const { product, selectedItem, selectedQuantity } = useProductSummary()
 
   const hoverBuyButton =
     equals(displayBuyButton, displayButtonTypes.DISPLAY_ALWAYS.value) ||
@@ -46,8 +46,6 @@ const ProductSummaryBuyButton = ({
 
   const containerClass = `${productSummary.buyButtonContainer} pv3 w-100 db`
 
-  // TODO: change ProductSummaryContext to have `selectedSku` field instead of `sku`
-  const selectedItem = product.sku
   const selectedSeller = path(['seller'], selectedItem)
   const isAvailable =
     selectedSeller &&
@@ -57,7 +55,7 @@ const ProductSummaryBuyButton = ({
     product,
     selectedItem,
     selectedSeller,
-    selectedQuantity: 1,
+    selectedQuantity,
   })
 
   return (

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -20,7 +20,8 @@
       "product-summary-add-to-list-button",
       "product-rating-inline",
       "product-teaser.summary",
-      "product-summary-brand"
+      "product-summary-brand",
+      "product-summary-quantity"
     ],
     "component": "ProductSummaryCustom",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added `product-summary-quantity` in the shelf

**NEEDS [THIS](https://github.com/vtex-apps/product-quantity/pull/4) TO WORK**

#### How should this be manually tested?

[workspace](https://iaronaraujo--storecomponents.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/63536281-a53a5b80-c4e9-11e9-8ec6-f32de4005db1.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
