### PR TITLE
protect against empty arrays in parsing from catalog function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Protect against empty arrays in parsing from catalog function.
 
 ## [2.34.0] - 2019-08-27
 ### Added

--- a/react/utils/normarlize.js
+++ b/react/utils/normarlize.js
@@ -76,14 +76,14 @@ export function mapCatalogProductToProductSummary(product, imageSize = 500) {
   const items = normalizedProduct.items || []
   const sku = items.find(findAvailableProduct) || items[0]
   if (sku) {
-    const [seller] = pathOr([defaultSeller], ['sellers'], sku)
-    const [referenceId] = pathOr([defaultReference], ['referenceId'], sku)
-    const catalogImages = pathOr([defaultImage], ['images'], sku)
+    const [seller = defaultSeller] = pathOr([], ['sellers'], sku)
+    const [referenceId = defaultReference] = pathOr([], ['referenceId'], sku)
+    const catalogImages = pathOr([], ['images'], sku)
     const normalizedImages = catalogImages.map(image => ({
       ...image,
       imageUrl: resizeImage(image.imageUrl, imageSize),
     }))
-    const [image] = normalizedImages
+    const [image = defaultImage] = normalizedImages
     normalizedProduct.sku = {
       ...sku,
       seller,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Properly protect against empty arrays, the old code would break when doint `const [image] = pathOr([default], ...); console.log(image.imageUrl)`

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://fidelis--lesters.myvtex.com/
#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
