### PR TITLE
Add customToastURL prop to ProductSummaryBuyButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customToastURL` prop to be passed down into `BuyButton`.
 
 ## [2.34.5] - 2019-09-13
 ### Fixed

--- a/docs/ProductSummaryBuyButton.md
+++ b/docs/ProductSummaryBuyButton.md
@@ -38,6 +38,7 @@ Through the Storefront, you can change the `ProductSummaryBuyButton`'s behavior 
 | `isOneClickBuy`     | `Boolean` | Should redirect to checkout after clicking on buy                                           | `false`               |
 | `buyButtonText`     | `String`  | Custom buy button text                                                                      |                       |
 | `displayBuyButton`  | `Enum`    | Set display mode of buy button (displayButtonAlways, displayButtonHover, displayButtonNone) | `displayButtonAlways` |
+| `customToastURL`  | `String`    | Set the link associated with the Toast created when adding an item to your cart.  | `/checkout/#/cart` |
 
 ### Styles API
 

--- a/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
@@ -18,6 +18,7 @@ const ProductSummaryBuyButton = ({
   displayBuyButton,
   isOneClickBuy,
   buyButtonText,
+  customToastURL,
   runtime: {
     hints: { mobile },
   },
@@ -63,6 +64,7 @@ const ProductSummaryBuyButton = ({
       <div className={containerClass}>
         <div className={buyButtonClasses}>
           <BuyButton
+            customToastURL={customToastURL}
             available={isAvailable}
             skuItems={skuItems}
             isOneClickBuy={isOneClickBuy}
@@ -89,6 +91,8 @@ ProductSummaryBuyButton.propTypes = {
   buyButtonText: PropTypes.string,
   /** Defines the display mode of buy button */
   displayBuyButton: PropTypes.oneOf(getDisplayButtonValues()),
+  /** A custom URL for the `VIEW CART` button inside the toast created by BuyButton */
+  customToastURL: PropTypes.string,
 }
 
 ProductSummaryBuyButton.defaultProps = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the same new prop being added to the `BuyButton` component from `vtex.store-components`. This should enable users to customize the URL linked to the Toast rendered by `BuyButton`.

#### What problem is this solving?

Enabling users to customize the URL.

#### How should this be manually tested?

Add an item from the Shelf here and click on the toast link, you should be taken to https://google.com

https://minicarttoast--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
