### PR TITLE
Fix/huge placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes issue where the image placeholder was getting huge.
 
 ## [2.37.0] - 2019-10-11
 ### Added

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -102,13 +102,26 @@ const ProductImageContent = ({
     parseFloat(heightProp || widthProp || 0),
   ]
 
+  const legacyContainerClasses = classNames(
+    productSummary.imageStackContainer,
+    productSummary.hoverEffect
+  )
+
+  const containerClassname = classNames(
+    'dib relative',
+    handles.imageContainer,
+    legacyContainerClasses
+  )
+
   if (!sku || hasError) {
     return (
-      <ImagePlaceholder
-        width={width}
-        height={height}
-        handle={handles.productImage}
-      />
+      <div className={containerClassname}>
+        <ImagePlaceholder
+          width={width}
+          height={height}
+          handle={handles.productImage}
+        />
+      </div>
     )
   }
 
@@ -141,17 +154,6 @@ const ProductImageContent = ({
     applyModifiers(handles.image, 'hover'),
     legacyImageClasses,
     productSummary.hoverImage
-  )
-
-  const legacyContainerClasses = classNames(
-    productSummary.imageStackContainer,
-    productSummary.hoverEffect
-  )
-
-  const containerClassname = classNames(
-    'dib relative',
-    handles.imageContainer,
-    legacyContainerClasses
   )
 
   const img = (

--- a/react/legacy/components/ProductSummaryPrice.js
+++ b/react/legacy/components/ProductSummaryPrice.js
@@ -68,9 +68,9 @@ ProductSummaryPrice.propTypes = {
   /** Set installments' visibility */
   showInstallments: PropTypes.bool,
   /** Text of selling Price's label */
-  labelSellingPrice: PropTypes.string,
+  labelSellingPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /** Text of selling Price's label */
-  labelListPrice: PropTypes.string,
+  labelListPrice: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /** Defines if the loading spinner is shown */
   isLoading: PropTypes.bool,
   /** Styles used in the container div */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where the ImagePlaceholder was getting huge and messing up with the layout.

Also makes proptypes slighltly more permissive, to fix warnings

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Go to https://www.als.com/clothing/pants/Womens?map=c,c,specificationFilter_7721 and scroll down until about page 6 or 7, and notice that there is a huge margin below the footer.

Doing the same on https://lbebber--alssports.myvtex.com/clothing/pants/Womens?map=c,c,specificationFilter_7721 shouldn't have this issue

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
