### PR TITLE
Set a max-width for the ProductSummary component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Set max-width of `300px` to `ProductSummary` component.
 
 ## [2.37.2] - 2019-10-15
 ### Added

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -12,6 +12,8 @@ import productSummary from '../productSummary.css'
 import { productShape } from '../utils/propTypes'
 import { mapCatalogProductToProductSummary } from '../utils/normalize'
 
+const PRODUCT_SUMMARY_MAX_WIDTH = 300
+
 const ProductSummaryCustom = ({ product, actionOnClick, children }) => {
   const { isLoading, isHovering } = useProductSummary()
   const dispatch = useProductSummaryDispatch()
@@ -75,6 +77,7 @@ const ProductSummaryCustom = ({ product, actionOnClick, children }) => {
         className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        style={{ maxWidth: `${PRODUCT_SUMMARY_MAX_WIDTH}px` }}
       >
         <Link
           className={`${productSummary.clearLink} h-100 flex flex-column`}

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -77,7 +77,7 @@ const ProductSummaryCustom = ({ product, actionOnClick, children }) => {
         className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        style={{ maxWidth: `${PRODUCT_SUMMARY_MAX_WIDTH}px` }}
+        style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
       >
         <Link
           className={`${productSummary.clearLink} h-100 flex flex-column`}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Limit the max-width of a ProductSummary component.

#### What problem is this solving?

Prevents `ProductSummary` from being stretched even though the content would not fill it up. 

#### How should this be manually tested?

https://productsummarywidth--storecomponents.myvtex.com/apparel---accessories
(Apply some filters to see what it looks like with less items)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
