### PR TITLE
Allow product-teaser.summary on product-summary-column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow `product-teaser.summary` on `product-summary-column`
 
 ## [2.41.0] - 2019-10-23
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -41,7 +41,8 @@
       "product-summary-space",
       "product-summary-add-to-list-button",
       "product-rating-inline",
-      "product-summary-specification-badges"
+      "product-summary-specification-badges",
+      "product-teaser.summary"
     ],
     "component": "Column",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow the use of product-teaser.summary on product-summary-column.

#### What problem is this solving?
 in my use case I already have a custom interface using product-teaser.summary to display custom discount labels (these discounts are coming from an external API), but I need the product-summary.shelf with two columns.

#### How should this be manually tested?
Use this blocks configuration
```
  "product-summary.shelf": {
    "children": [
      "product-summary-column#image",
      "product-summary-column#details",
      "product-summary-quantity",
      "product-summary-buy-button"
    ]
  },
  "product-summary-column#image": {
    "children": [
      "product-summary-image"
    ]
  },
  "product-summary-column#details": {
    "children": [
      "product-teaser.summary",
      "product-summary-name",
      "product-summary-price"
    ]
  }
```

#### Screenshots or example usage
![Screen Shot 2019-10-23 at 4 26 48 PM](https://user-images.githubusercontent.com/27775611/67427337-51fc8c00-f5b2-11e9-8c63-72a83af172a2.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
