### PR TITLE
Change product summary name space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `ProductSummaryName` line height.
 
 ## [2.43.0] - 2019-10-24
 ### Added

--- a/react/components/ProductSummaryName/ProductSummaryName.js
+++ b/react/components/ProductSummaryName/ProductSummaryName.js
@@ -24,7 +24,7 @@ const ProductSummaryName = ({ showFieldsProps }) => {
   const brandName = path(['brand'], product)
 
   const containerClasses = `${handles.nameContainer} flex items-start justify-center pv6`
-  const wrapperClasses = `${handles.nameWrapper} overflow-hidden c-on-base`
+  const wrapperClasses = `${handles.nameWrapper} overflow-hidden c-on-base f5`
   const brandNameClasses = `${handles.brandName} t-body`
   const skuNameClasses = `${handles.skuName} t-small`
   const loaderClasses = `${handles.productNameLoader} pt5 overflow-hidden`


### PR DESCRIPTION
#### What is the purpose of this pull request?
`ProductSummaryName` had a big line height

#### How should this be manually tested?
Enter in the [master workspace](https://summaryname--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721) to the the difference
[workspace](https://summaryname--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721)
#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
