### PR TITLE
Fix/product image contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make product image fit its container.
 
 ## [2.43.3] - 2019-11-01
 ### Fixed

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -53,12 +53,6 @@ const Image = ({ src, width, height, onError, alt, className }) => {
 
   const shouldResize = !!(width || height)
 
-  if (!shouldResize) {
-    console.warn(
-      'ProductSummaryImage: It is recommended that the props `width` and `height` of the block `product-summary-image` should be set, in order to be able to load the image with the optimal resolution, and to prevent contents from shifting around.'
-    )
-  }
-
   return (
     <img
       src={

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -67,11 +67,11 @@ const Image = ({ src, width, height, onError, alt, className }) => {
       style={
         shouldResize
           ? {
-              width,
+              width: '100%',
               height,
               objectFit: 'contain',
               maxHeight: 'unset',
-              maxWidth: 'unset',
+              maxWidth: width,
             }
           : null
       }

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -69,6 +69,7 @@ const Image = ({ src, width, height, onError, alt, className }) => {
           ? {
               width,
               height,
+              objectFit: 'contain',
               maxHeight: 'unset',
               maxWidth: 'unset',
             }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where the product image would grow larger than its container.

Before:
<img width="1052" alt="Screen Shot 2019-11-04 at 14 38 28" src="https://user-images.githubusercontent.com/5691711/68143723-d0d9b900-ff10-11e9-9587-e0dfbe4c61f6.png">

After:
<img width="1052" alt="Screen Shot 2019-11-04 at 14 38 15" src="https://user-images.githubusercontent.com/5691711/68143740-d931f400-ff10-11e9-8ed1-dccb09b79234.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://lbebber--gympassus.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
