### PR TITLE
Allow new interface from add-to-cart-button@0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `add-to-cart-button` to the allowed list for product-summary.shelf interface.
 
 ## [2.45.1] - 2019-11-19
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
     "vtex.css-handles": "0.x",
     "vtex.product-context": "0.x",
     "vtex.flex-layout": "0.x",
-    "vtex.rich-text": "0.x"
+    "vtex.rich-text": "0.x",
+    "vtex.add-to-cart-button": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -26,7 +26,8 @@
       "product-summary-specification-badges",
       "rich-text",
       "flex-layout",
-      "stack-layout"
+      "stack-layout",
+      "add-to-cart-button"
     ],
     "component": "ProductSummaryCustom",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `add-to-cart-button` to the allowed list for `product-summary.shelf` interface.

#### What problem is this solving?

Enables the user to use the new `add-to-cart-button`.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

**THIS SHOULD ONLY BE MERGED AFTER https://github.com/vtex-apps/add-to-cart-button/pull/1**
