### PR TITLE
Allow flex-layout and rich-text inside product-summary.shelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow `rich-text` and `flex-layout` inside `product-summary.shelf`.
 
 ## [2.44.0] - 2019-11-11
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,9 @@
     "vtex.stack-layout": "0.x",
     "vtex.responsive-values": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.product-context": "0.x"
+    "vtex.product-context": "0.x",
+    "vtex.flex-layout": "0.x",
+    "vtex.rich-text": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -24,6 +24,8 @@
       "product-summary-brand",
       "product-summary-quantity",
       "product-summary-specification-badges",
+      "rich-text",
+      "flex-layout",
       "stack-layout"
     ],
     "component": "ProductSummaryCustom",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make the layout of product-summary more flexible.
Make it possible to add custom texts inside of product-summary.

#### What problem is this solving?
A store wanted to add a text before the brand name, example ("Por")

![image](https://user-images.githubusercontent.com/284515/68627314-39e6a100-04bc-11ea-9b35-0e7acd32047c.png)


#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
