### PR TITLE
Allow `product-summary-brand` inside `product-summary-column`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Allow `product-summary-brand` inside `product-summary-column`
 
 ## [2.45.0] - 2019-11-11
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -44,7 +44,8 @@
       "product-summary-add-to-list-button",
       "product-rating-inline",
       "product-summary-specification-badges",
-      "product-teaser.summary"
+      "product-teaser.summary",
+      "product-summary-brand"
     ],
     "component": "Column",
     "composition": "children"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Have brand as a sibling of name that are children a of column interface 

#### What problem is this solving?
Easier layout alignment and less custom CSS to achieve the same feature.

#### How should this be manually tested?
https://dan--paguemenosqa.myvtex.com/

#### Screenshots or example usage
![Screen Shot 2019-11-18 at 2 28 27 PM](https://user-images.githubusercontent.com/27775611/69075834-f4245e00-0a10-11ea-98fe-618b8f20c680.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
