### PR TITLE
Verify selectedItem on shouldAddToCart Props

### DIFF
--- a/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
@@ -93,7 +93,7 @@ const ProductSummaryBuyButton = ({
             available={isAvailable}
             isOneClickBuy={isOneClickBuy}
             customToastURL={customToastURL}
-            shouldAddToCart={!shouldBeALink}
+            shouldAddToCart={selectedItem || !shouldBeALink}
           >
             <IOMessage id={buyButtonText} />
           </BuyButton>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a new validation at the "shouldAddToCart" props of the "BuyButton" component that allows the costumer select the SKU and add the product at the cart directly from any search-result page.

Example: https://nimb.ws/6ACwdq

#### What problem is this solving?

Without the old validation the value of "shouldAddToCart" props is always false, redirecting the user to the product page.

Example: https://nimb.ws/uM6BZc


#### How should this be manually tested?
You can test the bug at:
https://miniprix.myvtex.com/femei

and the solution at:
https://marcos--miniprix.myvtex.com/femei

#### Screenshots or example usage

How the code was working:
https://i.imgur.com/myupcgZ.png
https://i.imgur.com/pJwQPqo.png

My solution:
https://i.imgur.com/F0ZVWzq.png

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
