### PR TITLE
Add default styling for `product-summary-sku-selector`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "messages": "1.x",
     "store": "0.x",
     "react": "3.x",
-    "docs": "0.x"
+    "docs": "0.x",
+    "styles": "2.x"
   },
   "mustUpdateAt": "2019-04-02",
   "scripts": {

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -1,0 +1,3 @@
+.skuSelectorOptionsList {
+  justify-content: center;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add default styling for `product-summary-sku-selector` block.

#### What problem is this solving?

The default styling in the SKU Selector component does not look good when used inside a `product-summary`.

#### How should this be manually tested?

[workspace](https://skuselectorslide--storecomponents.myvtex.com/top?_q=top&map=ft)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
