### PR TITLE
Remove `containerRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+-  `containerRef` from `ProductSummary` since it doesn't need it anymore.
 
 ## [2.51.0] - 2020-02-06
 ### Added

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -23,7 +23,6 @@ const ProductSummaryCustom = ({
   product,
   actionOnClick,
   children,
-  containerRef,
 }) => {
   const { isLoading, isHovering, selectedItem, query } = useProductSummary()
   const dispatch = useProductSummaryDispatch()
@@ -122,8 +121,7 @@ const ProductSummaryCustom = ({
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
-          // If containerRef is passed, it should be used
-          ref={containerRef || inViewRef}
+          ref={inViewRef}
         >
           <Link
             className={linkClasses}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Removed `containerRef` from `ProductSummary` since it doesn't need it anymore. https://github.com/vtex-apps/shelf/pull/212

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
Go to the console, type `pixelManagerEvents` and check that the `productImpression` events are still being sent correctly.
