### PR TITLE
Handle error and loading states from productSearch query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing error handling logic for productSearch query.
 
 ## [2.51.0] - 2020-02-06
 ### Added

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -61,7 +61,7 @@ const ProductSummaryList = ({
   maxItems = 10,
   withFacets = false,
 }) => {
-  const { data } = useQuery(productSearchV2, {
+  const { data, loading, error } = useQuery(productSearchV2, {
     ssr: true,
     name: 'productList',
     variables: {
@@ -79,6 +79,11 @@ const ProductSummaryList = ({
       withFacets,
     },
   })
+
+  // TODO Improve this error handling in the future
+  if (loading || error) {
+    return null
+  }
 
   const { list } = useListContext()
   const { treePath } = useTreePath()

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -80,7 +80,7 @@ const ProductSummaryList = ({
     },
   })
 
-  // TODO Improve this error handling in the future
+  // https://github.com/vtex-apps/product-summary/issues/235
   if (loading || error) {
     return null
   }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -86,6 +86,10 @@
   "list-context.product-list": {
     "allowed": ["product-summary"],
     "composition": "children",
-    "component": "ProductSummaryList"
+    "component": "ProductSummaryList",
+    "preview": {
+      "type": "grid",
+      "height": 550
+    }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add error handling logic to `ProductSummaryList` for the `productSearch` query.

#### What problem is this solving?

`ProductSummaryList` could break while loading the query.

#### How should this be manually tested?

https://shelflayout--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
