### PR TITLE
Only display the mainImageLabel if no image variant sku is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Only display `mainImageLabel` image if no image variant sku is selected.
 
 ## [2.51.0] - 2020-02-06
 ### Added

--- a/react/__mocks__/vtex.product-context.js
+++ b/react/__mocks__/vtex.product-context.js
@@ -1,7 +1,11 @@
-import React, { createContext } from 'react'
+import React, { createContext, useContext } from 'react'
 
-const ProductContext = createContext({})
+const ProductContext = createContext({
+  skuSelector: {},
+})
 
 export const ProductContextProvider = ({ product, query, ...rest }) => {
   return <ProductContext.Provider value={{ product, query }} {...rest} />
 }
+
+export const useProduct = () => useContext(ProductContext)

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -95,7 +95,7 @@ const ProductImageContent = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
   const {
-    skuSelector: { selectedColorVariationSKU },
+    skuSelector: { selectedImageVariationSKU },
   } = useProduct()
 
   const { productClusters, productName: name } = product || {}
@@ -131,7 +131,7 @@ const ProductImageContent = ({
 
   let imageUrl = pathOr({}, ['image', 'imageUrl'], sku)
 
-  if (selectedColorVariationSKU == null && mainImageLabel) {
+  if (selectedImageVariationSKU == null && mainImageLabel) {
     const mainImage = findImageByLabel(images, mainImageLabel)
     if (mainImage) {
       imageUrl = mainImage.imageUrl

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -6,6 +6,8 @@ import classNames from 'classnames'
 import { useDevice } from 'vtex.device-detector'
 import { useResponsiveValues } from 'vtex.responsive-values'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+import { useProduct } from 'vtex.product-context'
+
 import ImagePlaceholder from './ImagePlaceholder'
 
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
@@ -90,12 +92,14 @@ const ProductImageContent = ({
   width: widthProp,
   height: heightProp,
 }) => {
-  const { productClusters, productName: name } = product || {}
-
-  const sku = product && product.sku
-
-  const { isMobile } = useDevice()
   const handles = useCssHandles(CSS_HANDLES)
+  const { isMobile } = useDevice()
+  const {
+    skuSelector: { selectedColorVariationSKU },
+  } = useProduct()
+
+  const { productClusters, productName: name } = product || {}
+  const sku = product && product.sku
 
   const [width, height] = [
     // fallsback to the other remaining value, if not defined
@@ -126,7 +130,8 @@ const ProductImageContent = ({
   const hoverImage = findImageByLabel(images, hoverImageLabel)
 
   let imageUrl = pathOr({}, ['image', 'imageUrl'], sku)
-  if (mainImageLabel) {
+
+  if (selectedColorVariationSKU == null && mainImageLabel) {
     const mainImage = findImageByLabel(images, mainImageLabel)
     if (mainImage) {
       imageUrl = mainImage.imageUrl

--- a/react/components/ProductSummarySKUSelector/index.js
+++ b/react/components/ProductSummarySKUSelector/index.js
@@ -47,10 +47,7 @@ function ProductSummarySKUSelector(props) {
   const handles = useCssHandles(CSS_HANDLES)
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div
-      onClick={stopBubblingUp}
-      className={handles.SKUSelectorContainer}
-    >
+    <div onClick={stopBubblingUp} className={handles.SKUSelectorContainer}>
       <SKUSelector onSKUSelected={handleSKUSelected} {...props} />
     </div>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Prevent the `mainImageLabel` from overriding the current selected sku.

Related to: https://github.com/vtex-apps/product-context/pull/19 and https://github.com/vtex-apps/store-components/pull/701

https://app.clubhouse.io/vtex/story/30770/mainimagelabel-should-not-affect-sku-selector-image-behavior

#### What problem is this solving?

Currently, if a client defines a `mainImageLabel`, it always override the images of the sku selectors.

#### How should this be manually tested?

1) https://kiwi--worldwidegolf.myvtex.com/
2) In `home`, check if the golf ball product is displaying a box
3) Click in a color variant
4) Image should change to that color
5) Click again, to remove the color
6) Should display the box again

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
