### PR TITLE
Remove query skuId if no sku is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove `skuId` from query string if no SKU is selected.
 
 ## [2.51.3] - 2020-02-11
 ### Changed

--- a/react/components/ProductSummarySKUSelector/index.js
+++ b/react/components/ProductSummarySKUSelector/index.js
@@ -18,6 +18,14 @@ function ProductSummarySKUSelector(props) {
   const { product } = useProductSummary()
 
   const handleSKUSelected = skuId => {
+    if (skuId == null) {
+      dispatch({
+        type: 'SET_PRODUCT_QUERY',
+        args: { query: '' },
+      })
+      return
+    }
+
     const selectedItem =
       product.items && product.items.find(item => item.itemId === skuId)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove the `skuId` from the query string of a product summary when some of the variations are unselected.

Related to: https://github.com/vtex-apps/store-components/pull/705

Clubhouse story: https://app.clubhouse.io/vtex/story/31692/improve-sku-selector-on-shelf-initialstate-empty

#### What problem is this solving?

Product summary redirecting to a specific SKU without the user fully interacting with the SKU Selector. If there's been no interaction, the user should be redirected to the product page with no `skuId` selected.

#### How should this be manually tested?

1. Go to: https://kiwi--worldwidegolf.myvtex.com/
2. In the shelf, check the url of a product with a lot of variations. It should have no skuId in its redirect URL.
3. Select a color SKU. It still should have no skuId in its URL.
4. Select all other variations. The URL now should contain the skuId=... parameter.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
