### PR TITLE
make prod-summary list consume products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `ProductSummaryList`: Consume new products query.
 
 ## [2.51.5] - 2020-02-21
 ### Changed

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -7,7 +7,7 @@ import { useListContext, ListContextProvider } from 'vtex.list-context'
 import { mapCatalogProductToProductSummary } from './utils/normalize'
 import ProductListEventCaller from './components/ProductListEventCaller'
 
-import productSearchV2 from 'vtex.store-resources/QueryProductSearchV2'
+import productsQuery from 'vtex.store-resources/QueryProducts'
 
 const ORDER_BY_OPTIONS = {
   RELEVANCE: {
@@ -59,10 +59,9 @@ const ProductSummaryList = ({
   orderBy = ORDER_BY_OPTIONS.TOP_SALE_DESC.value,
   specificationFilters = [],
   maxItems = 10,
-  withFacets = false,
+  skusFilter,
 }) => {
-  const { data, loading, error } = useQuery(productSearchV2, {
-    ssr: true,
+  const { data, loading, error } = useQuery(productsQuery, {
     name: 'productList',
     variables: {
       category,
@@ -76,7 +75,7 @@ const ProductSummaryList = ({
       from: 0,
       to: maxItems - 1,
       hideUnavailableItems,
-      withFacets,
+      skusFilter,
     },
   })
 
@@ -88,7 +87,7 @@ const ProductSummaryList = ({
   const { list } = useListContext()
   const { treePath } = useTreePath()
 
-  const products = data.productSearch && data.productSearch.products
+  const { products } = data
 
   const newListContextValue = useMemo(() => {
     const componentList =


### PR DESCRIPTION
#### What is the purpose of this pull request?
https://fidelis--storecomponents.myvtex.com/

The ProductSummaryList component should use another query, the same as the shelf component and not the productSearch query.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
