### PR TITLE
use new installment criteria in products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductSummaryList`: `installmentCriteeria` prop to use in `products` query.
+- `ProductSummaryList`: Messages and translations to be able to edit `skusFilter` and `installmentCriteria` in site editor.
 
 ## [2.51.7] - 2020-03-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ProductSummaryList`: `installmentCriteria` prop to use in `products` query.
 - `ProductSummaryList`: Messages and translations to be able to edit `skusFilter` and `installmentCriteria` in site editor.
 
+### Fixed
+- Props passed to `ProductSummaryList`
+
 ## [2.51.7] - 2020-03-02
 ### Changed
 - `ProductSummaryList`: Consume new products query.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ProductSummaryList`: `installmentCriteeria` prop to use in `products` query.
+- `ProductSummaryList`: `installmentCriteria` prop to use in `products` query.
 - `ProductSummaryList`: Messages and translations to be able to edit `skusFilter` and `installmentCriteria` in site editor.
 
 ## [2.51.7] - 2020-03-02

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -52,4 +52,3 @@ For `InstallmentCriteriaEnum`:
 | ---- | ----- | ----------- |
 | Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display price with maximum value before interest. |
 | Maximum with interest | `MAX_WITH_INTEREST` | Will display price with maximum value after interest applied. |
-| Minimum | `MIN` | Will display the lowest price before interest. |

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -50,5 +50,5 @@ For `InstallmentCriteriaEnum`:
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
-| Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display price with maximum value before interest. |
-| Maximum with interest | `MAX_WITH_INTEREST` | Will display price with maximum value after interest applied. |
+| Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display the maximum installment option with no interest. |
+| Maximum | `MAX_WITH_INTEREST` | Will display the maximum installment option having interest or not. |

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -35,3 +35,21 @@ This block is used to specify what variation of `product-summary` to be used to 
 | `orderBy`              | `Enum`                                 | Ordination type of the items. Possible values: `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` | `OrderByTopSaleDESC`          |
 | `hideUnavailableItems` | `Boolean`                              | Hides items that are unavailable.                                                                                                                                                                                                         | `false`       |
 | `maxItems` | `Number`                              | Maximum items to be fetched.                                                                                                                                                                                                         | `10`       |
+| `skusFilter`               | `SkusFilterEnum`                 | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                                                                    | `"ALL_AVAILABLE"` |
+| `installmentCriteria`               | `InstallmentCriteriaEnum`                 | ControlControl what pricee to be shown when price has different installments options.                                                                                                    | `"MAX_WITHOUT_INTEREST"` |
+
+For `SkusFilterEnum`:
+
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| First Available | `FIRST_AVAILABLE` | Most performant, ideal if you do not have a SKU selector in your shelf. Will return only the first available SKU for that product in your shelf query. |
+| All Available | `ALL_AVAILABLE` | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance. |
+| All | `ALL` | Returns all SKUs related to that product, least performant option. |
+
+For `InstallmentCriteriaEnum`:
+
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display price with maximum value before interest. |
+| Maximum with interest | `MAX_WITH_INTEREST` | Will display price with maximum value after interest applied. |
+| Minimum | `MIN` | Will display the lowest price before interest. |

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -36,7 +36,7 @@ This block is used to specify what variation of `product-summary` to be used to 
 | `hideUnavailableItems` | `Boolean`                              | Hides items that are unavailable.                                                                                                                                                                                                         | `false`       |
 | `maxItems` | `Number`                              | Maximum items to be fetched.                                                                                                                                                                                                         | `10`       |
 | `skusFilter`               | `SkusFilterEnum`                 | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                                                                    | `"ALL_AVAILABLE"` |
-| `installmentCriteria`               | `InstallmentCriteriaEnum`                 | ControlControl what pricee to be shown when price has different installments options.                                                                                                    | `"MAX_WITHOUT_INTEREST"` |
+| `installmentCriteria`               | `InstallmentCriteriaEnum`                 | ControlControl what price to be shown when price has different installments options.                                                                                                    | `"MAX_WITHOUT_INTEREST"` |
 
 For `SkusFilterEnum`:
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -63,6 +63,5 @@
   "admin/editor.productSummaryList.installmentCriteria.title": "Title of installment criteria property",
   "admin/editor.productSummaryList.installmentCriteria.description": "Description of installment criteria property",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest enum name",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest enum name",
-  "admin/editor.productSummaryList.installmentCriteria.min": "Minimum enum name"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest enum name"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -54,5 +54,15 @@
   "admin/editor.productSummaryList.orderType.nameDesc": "Name, descending",
   "admin/editor.productSummaryList.orderType.releaseDate": "Release Date",
   "admin/editor.productSummaryList.orderType.discount": "Discount",
-  "admin/editor.productSummaryList.orderType.relevance": "Relevance"
+  "admin/editor.productSummaryList.orderType.relevance": "Relevance",
+  "admin/editor.productSummaryList.skusFilter.title": "Title of skus filter property",
+  "admin/editor.productSummaryList.skusFilter.description": "Description of skus filter property",
+  "admin/editor.productSummaryList.skusFilter.none": "Value none of skus filter enum",
+  "admin/editor.productSummaryList.skusFilter.first-available": "Value first available of skus filter enum",
+  "admin/editor.productSummaryList.skusFilter.all-available": "Value all available of skus filter enum",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Title of installment criteria property",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Description of installment criteria property",
+  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest enum name",
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest enum name",
+  "admin/editor.productSummaryList.installmentCriteria.min": "Minimum enum name"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -60,8 +60,8 @@
   "admin/editor.productSummaryList.skusFilter.none": "None",
   "admin/editor.productSummaryList.skusFilter.first-available": "First available",
   "admin/editor.productSummaryList.skusFilter.all-available": "All available",
-  "admin/editor.productSummaryList.installmentCriteria.title": "Prices with Installment",
-  "admin/editor.productSummaryList.installmentCriteria.description": "Choose what type of prices to be showed in the products displayed (e.g.: maximum without interest or with interest, etc).",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Displayed installments",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Choose what type of installments to be showed (e.g.: maximum without interest or with interest).",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,5 +54,15 @@
   "admin/editor.productSummaryList.orderType.nameDesc": "Name, descending",
   "admin/editor.productSummaryList.orderType.releaseDate": "Release Date",
   "admin/editor.productSummaryList.orderType.discount": "Discount",
-  "admin/editor.productSummaryList.orderType.relevance": "Relevance"
+  "admin/editor.productSummaryList.orderType.relevance": "Relevance",
+  "admin/editor.productSummaryList.skusFilter.title": "SKUs Filter",
+  "admin/editor.productSummaryList.skusFilter.description": "Setting the first available filter might make your query much faster!",
+  "admin/editor.productSummaryList.skusFilter.none": "None",
+  "admin/editor.productSummaryList.skusFilter.first-available": "First available",
+  "admin/editor.productSummaryList.skusFilter.all-available": "All available",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Prices with Installment",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Choose what type of prices to be showed in the products displayed (e.g.: maximum without interest or with interest, etc).",
+  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest",
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest",
+  "admin/editor.productSummaryList.installmentCriteria.min": "Minimum"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -63,6 +63,5 @@
   "admin/editor.productSummaryList.installmentCriteria.title": "Prices with Installment",
   "admin/editor.productSummaryList.installmentCriteria.description": "Choose what type of prices to be showed in the products displayed (e.g.: maximum without interest or with interest, etc).",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest",
-  "admin/editor.productSummaryList.installmentCriteria.min": "Minimum"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -54,5 +54,15 @@
   "admin/editor.productSummaryList.orderType.nameDesc": "Nombre, descendiendo",
   "admin/editor.productSummaryList.orderType.releaseDate": "Fecha de lanzamiento",
   "admin/editor.productSummaryList.orderType.discount": "Descuento",
-  "admin/editor.productSummaryList.orderType.relevance": "Relevancia"
+  "admin/editor.productSummaryList.orderType.relevance": "Relevancia",
+  "admin/editor.productSummaryList.skusFilter.title": "Filtro de SKUs",
+  "admin/editor.productSummaryList.skusFilter.description": "¡Establecer el primer iten disponible agiliza su consulta!",
+  "admin/editor.productSummaryList.skusFilter.none": "Ninguno",
+  "admin/editor.productSummaryList.skusFilter.first-available": "Primero disponible",
+  "admin/editor.productSummaryList.skusFilter.all-available": "Todos disponibles",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Criterio de precio a plazos",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Elija qué tipo de precio se mostrará en los productos (por ejemplo, máximo sin interés, o con interés, etc.)",
+  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sin interés",
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo con interés",
+  "admin/editor.productSummaryList.installmentCriteria.min": "Mínimo"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -60,8 +60,8 @@
   "admin/editor.productSummaryList.skusFilter.none": "Ninguno",
   "admin/editor.productSummaryList.skusFilter.first-available": "Primero disponible",
   "admin/editor.productSummaryList.skusFilter.all-available": "Todos disponibles",
-  "admin/editor.productSummaryList.installmentCriteria.title": "Criterio de precio a plazos",
-  "admin/editor.productSummaryList.installmentCriteria.description": "Elija qué tipo de precio se mostrará en los productos (por ejemplo, máximo sin interés, o con interés, etc.)",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Criterio de cuotas",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Elija qué tipo de cuota se mostrará en los productos (p. Ej., Máximo sin interés o con interés).",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sin interés",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo con interés"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -63,6 +63,5 @@
   "admin/editor.productSummaryList.installmentCriteria.title": "Criterio de precio a plazos",
   "admin/editor.productSummaryList.installmentCriteria.description": "Elija qué tipo de precio se mostrará en los productos (por ejemplo, máximo sin interés, o con interés, etc.)",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sin interés",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo con interés",
-  "admin/editor.productSummaryList.installmentCriteria.min": "Mínimo"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo con interés"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -63,6 +63,5 @@
   "admin/editor.productSummaryList.installmentCriteria.title": "Preços com Parcelas",
   "admin/editor.productSummaryList.installmentCriteria.description": "Escolha qual tipo de preço a ser mostrado nos produtos (ex.: máximo sem juros, ou com juros, etc).",
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sem juros",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo com juros",
-  "admin/editor.productSummaryList.installmentCriteria.min": "Mínimo"
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo com juros"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -60,8 +60,8 @@
   "admin/editor.productSummaryList.skusFilter.none": "Nenhum",
   "admin/editor.productSummaryList.skusFilter.first-available": "Primeiro Disponível",
   "admin/editor.productSummaryList.skusFilter.all-available": "Todos Disponíveis",
-  "admin/editor.productSummaryList.installmentCriteria.title": "Preços com Parcelas",
-  "admin/editor.productSummaryList.installmentCriteria.description": "Escolha qual tipo de preço a ser mostrado nos produtos (ex.: máximo sem juros, ou com juros, etc).",
-  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sem juros",
-  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo com juros"
+  "admin/editor.productSummaryList.installmentCriteria.title": "Parcelamento",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Escolha qual tipo de parcelamento a ser mostrado nos produtos (ex.: máximo sem juros, ou com juros).",
+  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máxima sem juros",
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máxima"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -54,5 +54,15 @@
   "admin/editor.productSummaryList.orderType.nameDesc": "Nome, decrescente",
   "admin/editor.productSummaryList.orderType.releaseDate": "Data de lançamento",
   "admin/editor.productSummaryList.orderType.discount": "Desconto",
-  "admin/editor.productSummaryList.orderType.relevance": "Relevância"
+  "admin/editor.productSummaryList.orderType.relevance": "Relevância",
+  "admin/editor.productSummaryList.skusFilter.title": "Filtro de SKUs",
+  "admin/editor.productSummaryList.skusFilter.description": "Configurando o valor de primeiro disponível pode fazer sua query ser mais rápida!",
+  "admin/editor.productSummaryList.skusFilter.none": "Nenhum",
+  "admin/editor.productSummaryList.skusFilter.first-available": "Primeiro Disponível",
+  "admin/editor.productSummaryList.skusFilter.all-available": "Todos Disponíveis",
+  "admin/editor.productSummaryList.installmentCriteria.title": "Preços com Parcelas",
+  "admin/editor.productSummaryList.installmentCriteria.description": "Escolha qual tipo de preço a ser mostrado nos produtos (ex.: máximo sem juros, ou com juros, etc).",
+  "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sem juros",
+  "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo com juros",
+  "admin/editor.productSummaryList.installmentCriteria.min": "Mínimo"
 }

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -60,9 +60,9 @@ const ProductSummaryList = ({
   specificationFilters = [],
   maxItems = 10,
   skusFilter,
+  installmentCriteria,
 }) => {
   const { data, loading, error } = useQuery(productsQuery, {
-    name: 'productList',
     variables: {
       category,
       ...(collection != null
@@ -76,6 +76,7 @@ const ProductSummaryList = ({
       to: maxItems - 1,
       hideUnavailableItems,
       skusFilter,
+      installmentCriteria,
     },
   })
 
@@ -181,6 +182,30 @@ EnhancedProductList.getSchema = () => ({
       type: 'number',
       isLayout: false,
       default: 10,
+    },
+    skusFilter: {
+      title: 'admin/editor.productSummaryList.skusFilter.title',
+      description: 'admin/editor.productSummaryList.skusFilter.description',
+      type: 'string',
+      default: 'ALL_AVAILABLE',
+      enum: ['ALL_AVAILABLE', 'ALL', 'FIRST_AVAILABLE'],
+      enumNames: [
+        'admin/editor.productSummaryList.skusFilter.all-available',
+        'admin/editor.productSummaryList.skusFilter.none',
+        'admin/editor.productSummaryList.skusFilter.first-available'
+      ]
+    },
+    installmentCriteria: {
+      title: 'admin/editor.productSummaryList.installmentCriteria.title',
+      description: 'admin/editor.productSummaryList.installmentCriteria.description',
+      type: 'string',
+      default: 'MAX_WITHOUT_INTEREST',
+      enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST', 'MIN'],
+      enumNames: [
+        'admin/editor.productSummaryList.installmentCriteria.max-without-interest',
+        'admin/editor.productSummaryList.installmentCriteria.max-with-interest',
+        'admin/editor.productSummaryList.installmentCriteria.min'
+      ]
     },
   },
 })

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -203,8 +203,7 @@ EnhancedProductList.getSchema = () => ({
       enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST', 'MIN'],
       enumNames: [
         'admin/editor.productSummaryList.installmentCriteria.max-without-interest',
-        'admin/editor.productSummaryList.installmentCriteria.max-with-interest',
-        'admin/editor.productSummaryList.installmentCriteria.min'
+        'admin/editor.productSummaryList.installmentCriteria.max-with-interest'
       ]
     },
   },

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -200,7 +200,7 @@ EnhancedProductList.getSchema = () => ({
       description: 'admin/editor.productSummaryList.installmentCriteria.description',
       type: 'string',
       default: 'MAX_WITHOUT_INTEREST',
-      enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST', 'MIN'],
+      enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST'],
       enumNames: [
         'admin/editor.productSummaryList.installmentCriteria.max-without-interest',
         'admin/editor.productSummaryList.installmentCriteria.max-with-interest'

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -115,12 +115,12 @@ const ProductSummaryList = ({
   )
 }
 
-const EnhancedProductList = ({ children }) => {
+const EnhancedProductList = ({ children, ...props }) => {
   const { ProductListProvider } = ProductListContext
 
   return (
     <ProductListProvider>
-      <ProductSummaryList>{children}</ProductSummaryList>
+      <ProductSummaryList {...props}>{children}</ProductSummaryList>
       <ProductListEventCaller />
     </ProductListProvider>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Support new variable in products query `installmentsCriteria` to allow stores to display privces with interest.
Also make the values editable in site editor

https://fidelis--storecomponents.myvtex.com/

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
