### PR TITLE
Fix/hooks order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error caused by wrong hooks order on ProductSummaryList
 
 ## [2.52.0] - 2020-03-03
 ### Added

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -67,8 +67,8 @@ const ProductSummaryList = ({
       category,
       ...(collection != null
         ? {
-          collection,
-        }
+            collection,
+          }
         : {}),
       specificationFilters: specificationFilters.map(parseFilters),
       orderBy,
@@ -80,15 +80,10 @@ const ProductSummaryList = ({
     },
   })
 
-  // https://github.com/vtex-apps/product-summary/issues/235
-  if (loading || error) {
-    return null
-  }
-
   const { list } = useListContext()
   const { treePath } = useTreePath()
 
-  const { products } = data
+  const { products } = data || {}
 
   const newListContextValue = useMemo(() => {
     const componentList =
@@ -107,6 +102,11 @@ const ProductSummaryList = ({
       })
     return list.concat(componentList)
   }, [products, treePath, list])
+
+  // https://github.com/vtex-apps/product-summary/issues/235
+  if (loading || error) {
+    return null
+  }
 
   return (
     <ListContextProvider list={newListContextValue}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes error caused by wrong hooks order on ProductSummaryList.

If either `error` or `loading` were true, it wouldn't execute the hooks down below, which would throw an error if they were eventually false and the hooks executed.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
