### PR TITLE
Remove graphql tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- graphql-tag removed from deps since `parse`, from graphql-js already does the job. It is not ideal to use gql from 'graphql-tag' since our current webpack config only strips away the gql when explicitly importing, and not using gql in the code. 
 
 ## [2.52.1] - 2020-03-04
 ### Fixed

--- a/react/legacy/components/ProductQuantityStepper.js
+++ b/react/legacy/components/ProductQuantityStepper.js
@@ -151,21 +151,15 @@ class ProductQuantityStepper extends Component {
 }
 
 const withUpdateItemsMutation = graphql(UPDATE_ITEMS_MUTATION, {
-  props: ({ mutate }) => {
-    debugger
-    console.log('MUTATION withUpdateItemsMutation')
-    return ({
+  props: ({ mutate }) => ({
     updateItems: items => mutate({ variables: { items } }),
-  })},
+  }),
 })
 
 const withUpdateLocalItemsMutation = graphql(UPDATE_LOCAL_ITEMS_MUTATION, {
-  props: ({ mutate }) => {
-    debugger
-    console.log('MUTATION withUpdateLocalItemsMutation')
-    return ({
+  props: ({ mutate }) => ({
     updateLocalItems: items => mutate({ variables: { items } }),
-  })},
+  }),
 })
 
 export default compose(

--- a/react/legacy/components/ProductQuantityStepper.js
+++ b/react/legacy/components/ProductQuantityStepper.js
@@ -6,21 +6,21 @@ import { Pixel } from 'vtex.pixel-manager/PixelContext'
 import { debounce } from 'debounce'
 import { injectIntl, intlShape } from 'react-intl'
 import { compose, graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import { parse } from 'graphql'
 
 import { productShape } from '../../utils/propTypes'
 
-const UPDATE_ITEMS_MUTATION = gql`
+const UPDATE_ITEMS_MUTATION = parse(`
   mutation updateItems($items: [MinicartItem]) {
     updateItems(items: $items) @client
   }
-`
+`)
 
-const UPDATE_LOCAL_ITEMS_MUTATION = gql`
+const UPDATE_LOCAL_ITEMS_MUTATION = parse(`
   mutation updateLocalItems($items: [MinicartItem]) {
     updateLocalItems(items: $items) @client
   }
-`
+`)
 
 class ProductQuantityStepper extends Component {
   static propTypes = {
@@ -151,15 +151,21 @@ class ProductQuantityStepper extends Component {
 }
 
 const withUpdateItemsMutation = graphql(UPDATE_ITEMS_MUTATION, {
-  props: ({ mutate }) => ({
+  props: ({ mutate }) => {
+    debugger
+    console.log('MUTATION withUpdateItemsMutation')
+    return ({
     updateItems: items => mutate({ variables: { items } }),
-  }),
+  })},
 })
 
 const withUpdateLocalItemsMutation = graphql(UPDATE_LOCAL_ITEMS_MUTATION, {
-  props: ({ mutate }) => ({
+  props: ({ mutate }) => {
+    debugger
+    console.log('MUTATION withUpdateLocalItemsMutation')
+    return ({
     updateLocalItems: items => mutate({ variables: { items } }),
-  }),
+  })},
 })
 
 export default compose(

--- a/react/package.json
+++ b/react/package.json
@@ -10,7 +10,6 @@
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "graphql": "^14.1.1",
-    "graphql-tag": "^2.10.1",
     "ramda": "^0.26.1",
     "react": "^16.8.6",
     "react-apollo": "^2.4.1",
@@ -27,7 +26,7 @@
     "eslint-config-vtex-react": "^5.0.1",
     "intl": "^1.2.5",
     "prettier": "^1.18.2",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "vtexScriptsOverride": {
     "srcPath": "."

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2487,11 +2487,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-graphql-tag@^2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
-  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
-
 graphql-tag@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.8.0.tgz#52cdea07a842154ec11a2e840c11b977f9b835ce"
@@ -5121,10 +5116,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?
graphql-tag removed from deps since `parse`, from graphql-js already does the job. It is not ideal to use gql from 'graphql-tag' since our current webpack config only strips away the gql when explicitly importing, and not using gql in the code. 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
