### PR TITLE
Added Fixed Width and Fixed Height properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added fixed Width and Height props 
+
 ## [2.52.2] - 2020-03-11
 ### Removed
 - graphql-tag removed from deps since `parse`, from graphql-js already does the job. It is not ideal to use gql from 'graphql-tag' since our current webpack config only strips away the gql when explicitly importing, and not using gql in the code. 

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -48,7 +48,7 @@ const findImageByLabel = (images, selectedLabel) => {
   return images.find(({ imageLabel }) => imageLabel === selectedLabel)
 }
 
-const Image = ({ src, width, height, onError, alt, className }) => {
+const Image = ({ src, fixedWidth, fixedHeight, width, height, onError, alt, className }) => {
   const { isMobile } = useDevice()
 
   /** TODO: Previously it was as follows :
@@ -65,7 +65,7 @@ const Image = ({ src, width, height, onError, alt, className }) => {
   return (
     <img
       src={
-        shouldResize ? changeImageUrlSize(src, width * dpi, height * dpi) : src
+        (fixedWidth && fixedHeight) ? changeImageUrlSize(src, fixedWidth, fixedHeight) : shouldResize ? changeImageUrlSize(src, width * dpi, height * dpi) : src
       }
       style={
         shouldResize

--- a/react/legacy/components/ProductSummaryInline.js
+++ b/react/legacy/components/ProductSummaryInline.js
@@ -22,6 +22,8 @@ class ProductSummaryInline extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      fixedHeight,
+      fixedWidth
     } = this.props
 
     const containerClasses = classNames(
@@ -70,7 +72,7 @@ class ProductSummaryInline extends Component {
         >
           <article className="flex">
             <div className={`${productSummary.imageContainer} db w-70`}>
-              <ProductImage {...imageProps} />
+              <ProductImage {...imageProps} fixedHeight={fixedHeight} fixedWidth={fixedWidth} />
             </div>
             <div
               className={`${productSummary.information} w-80 pb2 pl3 flex flex-wrap flex-column justify-between`}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Fixed width and height needed for customizing the images in the shelf -->

#### What problem is this solving?
<!--- Customer wants a specific image sizing which does not go along with vtex shelf default values -->

#### How should this be manually tested?
If props provided in the blocks the image will be resized accordingly, otherwise the default vtex will be in place

#### Screenshots or example usage

    "product-summary": {
    "props": {
      "isOneClickBuy": false,
      "showBadge": true,
      "badgeText": "OFF",
      "displayBuyButton": "displayButtonHover",
      "showCollections": false,
      "showListPrice": true,
      "showLabels": false,
      "showInstallments": true,
      "showSavings": true,
      "fixedWidth":500,
      "fixedHeight": 500
    }

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ x ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
