### PR TITLE
Add aspectRatio on `ProductImage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `aspectRatio` and `maxHeight` on `ProductImage`.
 
 ## [2.52.3] - 2020-03-17
 ### Added

--- a/docs/ProductSummaryImage.md
+++ b/docs/ProductSummaryImage.md
@@ -48,6 +48,8 @@ Through the Storefront, you can change the `ProductSummaryImage`'s behavior and 
 | `mainImageLabel` | `String` | Works the same way as `hoverImageLabel` but to set the main image to display. If you pass a label and no image has that label, it will show the main image of the product | `""`|
 | `width` | `[ResponsiveInput<Number>](https://github.com/vtex-apps/responsive-values#vtexresponsive-values)`  | Sets the image width. | `undefined`          |
 | `height` | `[ResponsiveInput<Number>](https://github.com/vtex-apps/responsive-values#vtexresponsive-values)`  | Sets the image height. | `undefined`          |
+| `aspectRatio`             | `[ResponsiveInput<String>](https://github.com/vtex-apps/responsive-values#vtexresponsive-values)`                                   | Sets the aspect ratio of the image, that is, whether the image should be square, portrait, landscape, etc. The value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image)) i.e. two numbers separated by a colon such as `1:1` for square, `3:4` for upright portrait, or `1920:1080` for even large values). Note that this prop won't work if you use `width` or `height`. | `undefined`          |
+| `maxHeight` | `[ResponsiveInput<Number>](https://github.com/vtex-apps/responsive-values#vtexresponsive-values)`  | Sets the image max height. Note that this prop won't work if you use `width` or `height`.| `undefined`          |
 
 ### Styles API
 

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -46,7 +46,7 @@ const getStyle = (width, height, aspectRatio, maxHeight) => {
       maxHeight: maxHeight || 'unset',
     }
   } 
-  return null
+  return undefined
 }
 
 const maybeBadge = ({ listPrice, price, label }) => shouldShow => component => {

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -21,11 +21,11 @@ const DEFAULT_SIZE = 300
 const getImageSrc = (src, width, height, dpi, aspectRatio) => {
   if (width || height) {
     return changeImageUrlSize(src, width * dpi, height * dpi)
-  } else if (aspectRatio) {
+  } 
+  if (aspectRatio) {
     return imageUrl(src, DEFAULT_SIZE, MAX_SIZE, aspectRatio)
-  } else {
-    return src
-  }
+  } 
+  return src
 }
 
 const getStyle = (width, height, aspectRatio, maxHeight) => {
@@ -37,16 +37,16 @@ const getStyle = (width, height, aspectRatio, maxHeight) => {
       maxHeight: 'unset',
       maxWidth: width,
     }
-  } else if (aspectRatio || maxHeight) {
+  } 
+  if (aspectRatio || maxHeight) {
     return {
       width: '100%',
       height: '100%',
       objectFit: 'contain',
       maxHeight: maxHeight || 'unset',
     }
-  } else {
-    return null
-  }
+  } 
+  return null
 }
 
 const maybeBadge = ({ listPrice, price, label }) => shouldShow => component => {

--- a/react/utils/aspectRatioUtil.js
+++ b/react/utils/aspectRatioUtil.js
@@ -1,0 +1,61 @@
+import { changeImageUrlSize } from './normalize'
+
+/** Parses ratio values into a multiplier to set the image height.
+ * For example, turns "3:4" into 1.333, so the image height will be
+ * 1.333 times its width.
+ */
+const parseAspectRatio = input => {
+  if (!input) {
+    return null
+  }
+  if (typeof input === 'string') {
+    if (input === 'auto') {
+      return null
+    }
+    const separator = ':'
+    const data = input.split(separator)
+    if (data.length !== 2) {
+      return null
+    }
+
+    const [width, height] = data
+    const ratio = parseFloat(height) / parseFloat(width)
+
+    if (typeof ratio !== 'number' || isNaN(ratio)) {
+      return null
+    }
+
+    return ratio
+  }
+
+  if (typeof input === 'number') {
+    return input
+  }
+
+  return null
+}
+
+export const imageUrl = (src, size, maxSize, aspectRatio) => {
+  let width = size
+  let height = 'auto'
+
+  if (aspectRatio && aspectRatio !== 'auto') {
+    height = size * (parseAspectRatio(aspectRatio) || 1)
+
+    if (width > maxSize) {
+      height = height / (width / maxSize)
+      width = maxSize
+    }
+
+    if (height > maxSize) {
+      width = width / (height / maxSize)
+      height = maxSize
+    }
+
+    width = Math.round(width)
+    height = Math.round(height)
+  } else {
+    width = Math.min(maxSize, width)
+  }
+  return changeImageUrlSize(src, width, height)
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `aspectRatio` and `maxHeight` on `ProductImage`

#### How should this be manually tested?
[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
[Als](https://iaronaraujo--alssports.myvtex.com/Clothing/Shirts/Mens?map=c%2Cc%2CspecificationFilter_7721)
[Boticario](https://iaronaraujo--boticario.myvtex.com/)
[Exito](https://iaronaraujo--exitocol.myvtex.com/mercado/pollo-carne-y-pescado)
[Garmin](https://iaronaraujo--garmin.myvtex.com/)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/78793582-fa4bb480-7988-11ea-8938-f054a841ba7d.png)

