### PR TITLE
Fix product impression on legacy components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product Impression Events on legacy product summary.
 
 ## [2.53.1] - 2020-04-13
-
 ### Fixed
 - Product Summary Image - README.md Documentation 
 

--- a/react/__mocks__/react-intersection-observer.js
+++ b/react/__mocks__/react-intersection-observer.js
@@ -1,0 +1,6 @@
+
+export const useInView = (threshold, triggerOnce) => {
+  const inViewRef = undefined
+  const inView = threshold === triggerOnce
+  return [inViewRef, inView]
+}

--- a/react/legacy/components/ProductSummaryInline.js
+++ b/react/legacy/components/ProductSummaryInline.js
@@ -22,6 +22,7 @@ class ProductSummaryInline extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      inViewRef,
     } = this.props
 
     const containerClasses = classNames(
@@ -58,6 +59,7 @@ class ProductSummaryInline extends Component {
         className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        ref={inViewRef}
       >
         <Link
           className={summaryClasses}

--- a/react/legacy/components/ProductSummaryInlinePrice.js
+++ b/react/legacy/components/ProductSummaryInlinePrice.js
@@ -24,6 +24,7 @@ const ProductSummaryInlinePrice = ({
   priceAlignLeft,
   muted,
   index,
+  inViewRef,
 }) => {
   const containerClasses = classNames(
     styles.container,
@@ -68,6 +69,7 @@ const ProductSummaryInlinePrice = ({
       className={containerClasses}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      ref={inViewRef}
     >
       <article className={summaryClasses}>
         <Link

--- a/react/legacy/components/ProductSummaryNormal.js
+++ b/react/legacy/components/ProductSummaryNormal.js
@@ -25,6 +25,7 @@ class ProductSummaryNormal extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      inViewRef,
     } = this.props
 
     const containerClasses = classNames(
@@ -66,6 +67,7 @@ class ProductSummaryNormal extends Component {
         className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        ref={inViewRef}
       >
         <div className={`${productSummary.addToListBtn} absolute z-1 mt3`}>
           <ExtensionPoint

--- a/react/legacy/components/ProductSummarySmall.js
+++ b/react/legacy/components/ProductSummarySmall.js
@@ -23,6 +23,7 @@ class ProductSummarySmall extends Component {
       nameProps,
       priceProps,
       buyButtonProps,
+      inViewRef,
     } = this.props
 
     const containerClasses = classNames(
@@ -60,6 +61,7 @@ class ProductSummarySmall extends Component {
         className={containerClasses}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        ref={inViewRef}
       >
         <Link
           className={`${styles.clearLink} flex flex-column`}

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -121,12 +121,11 @@ class ProductSummary extends Component {
 
   sendImpressionEvent = () => {
     const {inView, productListDispatch} = this.props
-    if (inView) {
-      productListDispatch &&
-        productListDispatch({
-          type: 'SEND_IMPRESSION',
-          args: { product: this.props.product },
-        })
+    if (inView && productListDispatch) {
+      productListDispatch({
+        type: 'SEND_IMPRESSION',
+        args: { product: this.props.product },
+      })
     }
   }
 

--- a/react/legacy/index.js
+++ b/react/legacy/index.js
@@ -2,6 +2,8 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { ProductName, ProductPrice } from 'vtex.store-components'
+import { ProductListContext } from 'vtex.product-list-context'
+import { useInView } from 'react-intersection-observer'
 
 import ProductSummaryNormal from './components/ProductSummaryNormal'
 import ProductSummarySmall from './components/ProductSummarySmall'
@@ -105,6 +107,29 @@ class ProductSummary extends Component {
   handleItemsStateUpdate = isLoading =>
     this.setState({ isUpdatingItems: isLoading })
 
+  componentDidMount = () => {
+    this.sendImpressionEvent()
+  }
+
+  componentDidUpdate = (prevProps) => {
+    if (prevProps.productListDispatch !== this.props.productListDispatch ||
+      prevProps.inView !== this.props.inView ||
+      prevProps.product !== this.props.product) {
+        this.sendImpressionEvent()
+      }
+  }
+
+  sendImpressionEvent = () => {
+    const {inView, productListDispatch} = this.props
+    if (inView) {
+      productListDispatch &&
+        productListDispatch({
+          type: 'SEND_IMPRESSION',
+          args: { product: this.props.product },
+        })
+    }
+  }
+
   render() {
     const {
       product,
@@ -128,6 +153,7 @@ class ProductSummary extends Component {
       priceAlignLeft,
       muted,
       index,
+      inViewRef,
     } = this.props
 
     const imageProps = {
@@ -177,9 +203,30 @@ class ProductSummary extends Component {
         priceAlignLeft={priceAlignLeft}
         muted={muted}
         index={index}
+        inViewRef={inViewRef}
       />
     )
   }
+}
+
+
+const ProductSummaryWrapper = props => {
+  const { useProductListDispatch } = ProductListContext
+  const productListDispatch = useProductListDispatch()
+  const [inViewRef, inView] = useInView({
+    // Triggers the event when the element is 75% visible
+    threshold: 0.75,
+    triggerOnce: true,
+  })
+
+  return (
+    <ProductSummary
+      { ...props }
+      productListDispatch={productListDispatch}
+      inView={inView}
+      inViewRef={inViewRef}
+    />
+  )
 }
 
 const defaultSchema = {
@@ -218,7 +265,7 @@ const defaultSchema = {
   },
 }
 
-ProductSummary.getSchema = () => {
+ProductSummaryWrapper.getSchema = () => {
   const nameSchema = ProductName.schema
   return {
     ...defaultSchema,
@@ -229,4 +276,4 @@ ProductSummary.getSchema = () => {
   }
 }
 
-export default ProductSummary
+export default ProductSummaryWrapper


### PR DESCRIPTION
#### What is the purpose of this pull request?

The legacy components weren't sending impression events. This PR fixes this

#### How should this be manually tested?

[Workspace](https://iaronaraujo--melimeloparis.myvtex.com/femei/Bijuterii?__bindingAddress=www.melimeloparis.ro/)
Go on console, type `pixelManagerEvents` and check that the `productImpression` event is being sent.