### PR TITLE
Validation added at `shouldAddToCart` prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Validation added at `shouldAddToCart` prop.
 
 ## [2.53.2] - 2020-04-16
 ### Fixed

--- a/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
+++ b/react/components/ProductSummaryBuyButton/ProductSummaryBuyButton.js
@@ -49,18 +49,11 @@ const ProductSummaryBuyButton = ({
       mobile
     )
 
-  const buyButtonClasses = classnames(
-    handles.buyButton,
-    'center mw-100',
-    {
-      [productSummary.isHidden]: !hoverBuyButton,
-    }
-  )
+  const buyButtonClasses = classnames(handles.buyButton, 'center mw-100', {
+    [productSummary.isHidden]: !hoverBuyButton,
+  })
 
-  const containerClass = classnames(
-    handles.buyButtonContainer,
-    'pv3 w-100 db'
-  )
+  const containerClass = classnames(handles.buyButtonContainer, 'pv3 w-100 db')
 
   const selectedSeller = path(['seller'], selectedItem)
   const isAvailable =
@@ -77,9 +70,11 @@ const ProductSummaryBuyButton = ({
   const { items = [] } = product
   // if the item is not available the behavior is just show the disabled BuyButton,
   // but you still can go to the product page clicking in the summary
-  const shouldBeALink =
-    (items.length !== 1 || buyButtonBehavior !== DEFAULT_BUTTON_BEHAVIOR) &&
-    isAvailable
+
+  const shouldAddToCart =
+    ((items.length !== 1 || buyButtonBehavior !== DEFAULT_BUTTON_BEHAVIOR) &&
+      isAvailable) ||
+    selectedItem
 
   return (
     showBuyButton && (
@@ -93,7 +88,7 @@ const ProductSummaryBuyButton = ({
             available={isAvailable}
             isOneClickBuy={isOneClickBuy}
             customToastURL={customToastURL}
-            shouldAddToCart={!shouldBeALink}
+            shouldAddToCart={shouldAddToCart}
           >
             <IOMessage id={buyButtonText} />
           </BuyButton>


### PR DESCRIPTION
What is the purpose of this pull request?
Add a new validation at the "shouldAddToCart" props of the "BuyButton" component that allows the costumer select the SKU and add the product at the cart directly from any search-result page.

Example: https://nimb.ws/6ACwdq

What problem is this solving?
Without the old validation the value of "shouldAddToCart" props is always false, redirecting the user to the product page.

Example: https://nimb.ws/uM6BZc

How should this be manually tested?
You can test the bug at:
https://miniprix.myvtex.com/femei

and the solution at:
https://addtocart--miniprix.myvtex.com/femei

Screenshots or example usage
How the code was working:
https://i.imgur.com/myupcgZ.png
https://i.imgur.com/pJwQPqo.png

My solution:
https://i.imgur.com/F0ZVWzq.png