### PR TITLE
Fix collection variable of wrong type being used to perform Product Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `collection` prop in `ProductSummaryList`'s schema had the wrong type, which caused it to receive invalid values from CMS.
 
 ## [2.53.2] - 2020-04-16
 ### Fixed

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -160,7 +160,7 @@ EnhancedProductList.getSchema = () => ({
     },
     collection: {
       title: 'admin/editor.productSummaryList.collection.title',
-      type: 'number',
+      type: 'string',
       isLayout: false,
     },
     orderBy: {
@@ -192,19 +192,20 @@ EnhancedProductList.getSchema = () => ({
       enumNames: [
         'admin/editor.productSummaryList.skusFilter.all-available',
         'admin/editor.productSummaryList.skusFilter.none',
-        'admin/editor.productSummaryList.skusFilter.first-available'
-      ]
+        'admin/editor.productSummaryList.skusFilter.first-available',
+      ],
     },
     installmentCriteria: {
       title: 'admin/editor.productSummaryList.installmentCriteria.title',
-      description: 'admin/editor.productSummaryList.installmentCriteria.description',
+      description:
+        'admin/editor.productSummaryList.installmentCriteria.description',
       type: 'string',
       default: 'MAX_WITHOUT_INTEREST',
       enum: ['MAX_WITHOUT_INTEREST', 'MAX_WITH_INTEREST'],
       enumNames: [
         'admin/editor.productSummaryList.installmentCriteria.max-without-interest',
-        'admin/editor.productSummaryList.installmentCriteria.max-with-interest'
-      ]
+        'admin/editor.productSummaryList.installmentCriteria.max-with-interest',
+      ],
     },
   },
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix an issue where the Product query performed by `ProductSummaryList` would result in an Internal Server Error.

![Screen Shot 2020-04-24 at 09 56 14](https://user-images.githubusercontent.com/27777263/80216533-8cec8480-8614-11ea-91fb-d5f2231d56bf.png)

#### What problem is this solving?

The `collection` prop received by the `ProductSummaryList` component was receiving an invalid value from the CMS due to its type being wrong in the component's `schema`.

While `collection` should be `string` value, it was defined in the component's schema as a `number`.

#### How should this be manually tested?

Go to this [Workspace](https://victorhmp--storecomponents.myvtex.com/admin/cms/site-editor) and set an existing `collection` value in `ProductList`'s content configuration.

#### Types of changes
- [x] Bugfix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
