### PR TITLE
`customPath` prop in `ProductSummaryCustom`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customPath` prop in `ProductSummaryCustom` 
 
 ## [2.53.3] - 2020-04-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `customPath` prop in `ProductSummaryCustom` 
+- `href` prop in `ProductSummaryCustom` 
 
 ## [2.53.3] - 2020-04-24
 ### Fixed

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -23,6 +23,7 @@ const ProductSummaryCustom = ({
   product,
   actionOnClick,
   children,
+  customPath,
 }) => {
   const { isLoading, isHovering, selectedItem, query } = useProductSummary()
   const dispatch = useProductSummaryDispatch()
@@ -123,18 +124,28 @@ const ProductSummaryCustom = ({
           style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
           ref={inViewRef}
         >
-          <Link
-            className={linkClasses}
-            page="store.product"
-            params={{
-              slug: product && product.linkText,
-              id: product && product.productId,
-            }}
-            query={query}
-            onClick={actionOnClick}
-          >
-            <article className={summaryClasses}>{children}</article>
-          </Link>
+          {customPath ? (
+            <Link
+              className={linkClasses}
+              to={customPath}
+              onClick={actionOnClick}
+            >
+              <article className={summaryClasses}>{children}</article>
+            </Link>
+          ) : (
+            <Link
+              className={linkClasses}
+              page="store.product"
+              params={{
+                slug: product && product.linkText,
+                id: product && product.productId,
+              }}
+              query={query}
+              onClick={actionOnClick}
+            >
+              <article className={summaryClasses}>{children}</article>
+            </Link>
+          )}
         </section>
       </ProductContextProvider>
     </ProductSummaryContext.Provider>

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -158,6 +158,8 @@ ProductSummaryCustom.propTypes = {
     // Or the instance of a DOM native element
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.Element) }),
   ]),
+  /** Should be only used by custom components, never by blocks */
+  customPath: PropTypes.string,
 }
 
 function ProductSummaryWrapper(props) {

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -114,6 +114,19 @@ const ProductSummaryCustom = ({
     selectedItem
   )
 
+  const linkProps = customPath
+    ? {
+        to: customPath,
+      }
+    : {
+        page: 'store.product',
+        params: {
+          slug: product && product.linkText,
+          id: product && product.productId,
+        },
+        query: query,
+      }
+
   return (
     <ProductSummaryContext.Provider value={oldContextProps}>
       <ProductContextProvider product={product} query={{ skuId }}>
@@ -124,28 +137,9 @@ const ProductSummaryCustom = ({
           style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
           ref={inViewRef}
         >
-          {customPath ? (
-            <Link
-              className={linkClasses}
-              to={customPath}
-              onClick={actionOnClick}
-            >
-              <article className={summaryClasses}>{children}</article>
-            </Link>
-          ) : (
-            <Link
-              className={linkClasses}
-              page="store.product"
-              params={{
-                slug: product && product.linkText,
-                id: product && product.productId,
-              }}
-              query={query}
-              onClick={actionOnClick}
-            >
-              <article className={summaryClasses}>{children}</article>
-            </Link>
-          )}
+          <Link className={linkClasses} {...linkProps} onClick={actionOnClick}>
+            <article className={summaryClasses}>{children}</article>
+          </Link>
         </section>
       </ProductContextProvider>
     </ProductSummaryContext.Provider>

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -23,7 +23,7 @@ const ProductSummaryCustom = ({
   product,
   actionOnClick,
   children,
-  customPath,
+  href,
 }) => {
   const { isLoading, isHovering, selectedItem, query } = useProductSummary()
   const dispatch = useProductSummaryDispatch()
@@ -114,9 +114,9 @@ const ProductSummaryCustom = ({
     selectedItem
   )
 
-  const linkProps = customPath
+  const linkProps = href
     ? {
-        to: customPath,
+        to: href,
       }
     : {
         page: 'store.product',
@@ -159,7 +159,7 @@ ProductSummaryCustom.propTypes = {
     PropTypes.shape({ current: PropTypes.instanceOf(PropTypes.Element) }),
   ]),
   /** Should be only used by custom components, never by blocks */
-  customPath: PropTypes.string,
+  href: PropTypes.string,
 }
 
 function ProductSummaryWrapper(props) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding a `customPath` prop in `ProductSummaryCustom` allow to custom apps to use the product-summary and its Contexts, avoiding custom Apps creating new components.

There are two cases, in our case we want to redirect the use to another store in some shelfs, with this prop we can use set a correct link to the store that have the product. In other case, on the TokStok Weeding List, the product-summary do not have a link because the product-summary is just to show the product and use the custom "Add to List Button".

This is a Chaordic API context in the first, and the second is a private TokStok API.

1. https://custompath--carrefourbr.myvtex.com/vinho?_q=vinho&map=ft
2. https://tokstoklista.myvtex.com/casamento/guyas

#### What problem is this solving?
This will help to use the product-summary behaviors on custom apps easely.

#### How should this be manually tested?
On these to sites:
1. https://custompath--carrefourbr.myvtex.com/vinho?_q=vinho&map=ft
2. https://tokstoklista.myvtex.com/casamento/guyas

#### Screenshots or example usage
An example on our custom App:
![image](https://user-images.githubusercontent.com/49173685/81099569-80eca680-8ee1-11ea-94ce-84ee94a16d07.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
