### PR TITLE
Add tag prop on Product Name block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New prop `tag` on `ProductSummaryName`
 
 ## [2.54.2] - 2020-05-28
 

--- a/docs/ProductSummaryName.md
+++ b/docs/ProductSummaryName.md
@@ -37,7 +37,7 @@ You can find all options available in [Store Components Product Name app](https:
 
 | Prop name | Type | Description | Default value |
 | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| `tag` | `string` | Witch HTML element will render | `'h1'` |
+| `tag` | `string` | Which HTML element will render | `'h1'` |
 
 ### Styles API
 

--- a/docs/ProductSummaryName.md
+++ b/docs/ProductSummaryName.md
@@ -35,6 +35,10 @@ Through the Storefront, you can change the `ProductSummaryName`'s behavior and i
 
 You can find all options available in [Store Components Product Name app](https://github.com/vtex-apps/store-components/blob/master/react/components/ProductName/README.md).
 
+| Prop name | Type | Description | Default value |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `tag` | `string` | Witch HTML element will render | `'h1'` |
+
 ### Styles API
 
 This app provides some CSS classes as an API for style customization.

--- a/react/components/ProductSummaryName/ProductSummaryName.js
+++ b/react/components/ProductSummaryName/ProductSummaryName.js
@@ -53,6 +53,7 @@ ProductSummaryName.defaultProps = {
     showBrandName: false,
     showSku: false,
   },
+  tag: 'h1'
 }
 
 ProductSummaryName.propTypes = {

--- a/react/components/ProductSummaryName/ProductSummaryName.js
+++ b/react/components/ProductSummaryName/ProductSummaryName.js
@@ -15,7 +15,7 @@ const CSS_HANDLES = [
   'productNameLoader',
 ]
 
-const ProductSummaryName = ({ showFieldsProps }) => {
+const ProductSummaryName = ({ showFieldsProps, tag }) => {
   const { product } = useProductSummary()
   const handles = useCssHandles(CSS_HANDLES)
   const productName = path(['productName'], product)
@@ -40,6 +40,7 @@ const ProductSummaryName = ({ showFieldsProps }) => {
         name={productName}
         skuName={skuName}
         brandName={brandName}
+        tag={tag}
         {...showFieldsProps}
       />
     </div>
@@ -57,6 +58,7 @@ ProductSummaryName.defaultProps = {
 ProductSummaryName.propTypes = {
   /** Name schema props */
   showFieldsProps: PropTypes.object,
+  tag: PropTypes.string,
 }
 
 ProductSummaryName.getSchema = () => {

--- a/react/components/ProductSummaryName/ProductSummaryName.js
+++ b/react/components/ProductSummaryName/ProductSummaryName.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { path } from 'ramda'
 import { ProductName } from 'vtex.store-components'
 import { useCssHandles } from 'vtex.css-handles'
-
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
 
 const CSS_HANDLES = [
@@ -53,7 +52,7 @@ ProductSummaryName.defaultProps = {
     showBrandName: false,
     showSku: false,
   },
-  tag: 'h1'
+  tag: 'h1',
 }
 
 ProductSummaryName.propTypes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Many clients comments about the `<h1>` on the product-summary. We talked a lot about this but the majority of them want to fight and discuss about this and about the Google, SEO and etc.

#### What problem is this solving?
Some of these clients will stop to discuss and losing time if its possible to change.

#### How should this be manually tested?
Workspace link: https://gus--carrefourbr.myvtex.com/

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/49173685/83570088-d83f6000-a4fb-11ea-97c0-e6052dfe02be.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
