### PR TITLE
Add selectedItem prop to `ProductSummary` and `ProductImage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `selectedItem` prop to `ProductSummary` and `ProductImage`.
+
 ## [2.57.1] - 2020-07-09
 ### Fixed
 - Updated Product Summary and Product Summary Buy Button docs to create a clearer information about Minicart versions.

--- a/react/components/ProductSummary.js
+++ b/react/components/ProductSummary.js
@@ -14,13 +14,19 @@ import { ProductContextProvider } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
 
 import ProductSummaryContext from './ProductSummaryContext'
-import { productShape } from '../utils/propTypes'
+import { productShape, skuShape } from '../utils/propTypes'
 import { mapCatalogProductToProductSummary } from '../utils/normalize'
 
 const PRODUCT_SUMMARY_MAX_WIDTH = 300
 const CSS_HANDLES = ['container', 'containerNormal', 'element', 'clearLink']
 
-const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
+const ProductSummaryCustom = ({
+  product,
+  actionOnClick,
+  children,
+  href,
+  selectedItem: currentSelectedItem,
+}) => {
   const { isLoading, isHovering, selectedItem, query } = useProductSummary()
   const dispatch = useProductSummaryDispatch()
   const handles = useCssHandles(CSS_HANDLES)
@@ -52,10 +58,10 @@ const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
     if (product) {
       dispatch({
         type: 'SET_PRODUCT',
-        args: { product },
+        args: { product, selectedItem: currentSelectedItem || selectedItem },
       })
     }
-  }, [product, dispatch])
+  }, [product, dispatch, selectedItem, currentSelectedItem])
 
   const handleMouseLeave = useCallback(() => {
     dispatch({
@@ -84,11 +90,19 @@ const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
   const oldContextProps = useMemo(
     () => ({
       product,
+      selectedItem: currentSelectedItem || selectedItem,
       isLoading,
       isHovering,
       handleItemsStateUpdate: handleItemsStateUpdate,
     }),
-    [product, isLoading, isHovering, handleItemsStateUpdate]
+    [
+      product,
+      currentSelectedItem,
+      selectedItem,
+      isLoading,
+      isHovering,
+      handleItemsStateUpdate,
+    ]
   )
 
   const containerClasses = classNames(
@@ -107,7 +121,7 @@ const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
   const skuId = pathOr(
     path(['sku', 'itemId'], product),
     ['itemId'],
-    selectedItem
+    currentSelectedItem || selectedItem
   )
 
   const linkProps = href
@@ -125,7 +139,11 @@ const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
 
   return (
     <ProductSummaryContext.Provider value={oldContextProps}>
-      <ProductContextProvider product={product} query={{ skuId }}>
+      <ProductContextProvider
+        product={product}
+        selectedItem={currentSelectedItem || selectedItem}
+        query={{ skuId }}
+      >
         <section
           className={containerClasses}
           onMouseEnter={handleMouseEnter}
@@ -145,6 +163,8 @@ const ProductSummaryCustom = ({ product, actionOnClick, children, href }) => {
 ProductSummaryCustom.propTypes = {
   /** Product that owns the informations */
   product: productShape,
+  /** Selected Item. Should be only used by custom components, never by blocks */
+  selectedItem: skuShape,
   /** Function that is executed when a product is clicked */
   actionOnClick: PropTypes.func,
   children: PropTypes.node,

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -116,6 +116,7 @@ const Image = ({
 
 const ProductImageContent = ({
   product,
+  selectedItem,
   onError,
   hasError,
   showBadge,
@@ -134,7 +135,7 @@ const ProductImageContent = ({
   const { skuSelector: { selectedImageVariationSKU } = {} } = useProduct()
 
   const { productClusters, productName: name } = product || {}
-  const sku = product && product.sku
+  const sku = selectedItem || (product && product.sku)
 
   const [width, height] = [
     // fallsback to the other remaining value, if not defined
@@ -156,7 +157,9 @@ const ProductImageContent = ({
   const images = pathOr([], ['images'], sku)
   const hoverImage = findImageByLabel(images, hoverImageLabel)
 
-  let imageUrl = pathOr('', ['image', 'imageUrl'], sku)
+  let imageUrl =
+    pathOr('', ['image', 'imageUrl'], sku) ||
+    pathOr('', [0, 'imageUrl'], images)
 
   if (!imageUrl || hasError) {
     return (
@@ -244,8 +247,7 @@ const ProductImage = ({
   aspectRatio: aspectRatioProp,
   maxHeight: maxHeightProp,
 }) => {
-  const { product } = useProductSummary()
-
+  const { product, selectedItem } = useProductSummary()
   const {
     widthProp: width,
     heightProp: height,
@@ -273,6 +275,7 @@ const ProductImage = ({
         maxHeight={maxHeight}
         hasError={error}
         product={product}
+        selectedItem={selectedItem}
         badgeText={badgeText}
         showBadge={showBadge}
         displayMode={displayMode}

--- a/react/utils/propTypes.js
+++ b/react/utils/propTypes.js
@@ -23,6 +23,47 @@ export const removedOptionShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
 })
 
+export const skuShape = PropTypes.shape({
+  /** SKU name */
+  name: PropTypes.string.isRequired,
+  /** SKU id */
+  itemId: PropTypes.string.isRequired,
+  /** SKU Image to be shown */
+  image: PropTypes.shape({
+    /** Image URL */
+    imageUrl: PropTypes.string.isRequired,
+    /** Image tag as string */
+    imageTag: PropTypes.string,
+  }).isRequired,
+  /** SKU seller */
+  seller: PropTypes.shape({
+    /** Seller id */
+    sellerId: PropTypes.string,
+    /** Seller comertial offer */
+    commertialOffer: PropTypes.shape({
+      /** SKU installments */
+      Installments: PropTypes.arrayOf(
+        PropTypes.shape({
+          /** Installment value */
+          Value: PropTypes.number.isRequired,
+          /** Interest rate (zero if interest-free) */
+          InterestRate: PropTypes.number.isRequired,
+          /** Calculated total value */
+          TotalValuePlusInterestRate: PropTypes.number,
+          /** Number of installments */
+          NumberOfInstallments: PropTypes.number.isRequired,
+          /** Installments offer name */
+          Name: PropTypes.string,
+        })
+      ),
+      /** Selling Price */
+      Price: PropTypes.number.isRequired,
+      /** List Price */
+      ListPrice: PropTypes.number.isRequired,
+    }).isRequired,
+  }).isRequired,
+})
+
 export const productShape = PropTypes.shape({
   /** Product's id */
   productId: PropTypes.string.isRequired,
@@ -35,46 +76,7 @@ export const productShape = PropTypes.shape({
   /** Product's brand id */
   brandId: PropTypes.number,
   /** Product's SKU */
-  sku: PropTypes.shape({
-    /** SKU name */
-    name: PropTypes.string.isRequired,
-    /** SKU id */
-    itemId: PropTypes.string.isRequired,
-    /** SKU Image to be shown */
-    image: PropTypes.shape({
-      /** Image URL */
-      imageUrl: PropTypes.string.isRequired,
-      /** Image tag as string */
-      imageTag: PropTypes.string,
-    }).isRequired,
-    /** SKU seller */
-    seller: PropTypes.shape({
-      /** Seller id */
-      sellerId: PropTypes.string,
-      /** Seller comertial offer */
-      commertialOffer: PropTypes.shape({
-        /** SKU installments */
-        Installments: PropTypes.arrayOf(
-          PropTypes.shape({
-            /** Installment value */
-            Value: PropTypes.number.isRequired,
-            /** Interest rate (zero if interest-free) */
-            InterestRate: PropTypes.number.isRequired,
-            /** Calculated total value */
-            TotalValuePlusInterestRate: PropTypes.number,
-            /** Number of installments */
-            NumberOfInstallments: PropTypes.number.isRequired,
-            /** Installments offer name */
-            Name: PropTypes.string,
-          })
-        ),
-        /** Selling Price */
-        Price: PropTypes.number.isRequired,
-        /** List Price */
-        ListPrice: PropTypes.number.isRequired,
-      }).isRequired,
-    }).isRequired,
-  }).isRequired,
+  sku: skuShape.isRequired,
   /** Product's collections */
   productClusters: PropTypes.arrayOf(
     PropTypes.shape({


### PR DESCRIPTION
#### What problem is this solving?
Currently, it is not possible to pass a specific item to `ProductSummary` and it only displays the product information.
With the `Buy Together` shelf, we want to make it possible for the user to buy specific products directly from the shelf, for this we need the information of the selectedItem.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace without selectedItem](https://thalyta1--storecomponents.myvtex.com/blouse-with-knot/p?skuId=310124164)
[Workspace with selectedItem](https://selecteditem--storecomponents.myvtex.com/blouse-with-knot/p?skuId=310124164)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

This PR depends on https://github.com/vtex-apps/product-summary-context/pull/10

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
