### PR TITLE
Added product-summary-sku-name

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,5 @@
     "node": true,
     "es6": true,
     "jest": true
-  },
-  "parser": "babel-eslint"
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,5 +5,6 @@
     "node": true,
     "es6": true,
     "jest": true
-  }
+  },
+  "parser": "babel-eslint"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- new `product-summary-sku-name`
 
 ## [2.58.4] - 2020-08-25
 ### Fixed

--- a/docs/ProductSummarySKUName.md
+++ b/docs/ProductSummarySKUName.md
@@ -1,58 +1,54 @@
-# Product Summary Name
+📢 Use this project, [contribute](https://github.com/vtex-apps/product-summary) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
-## Description
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
-`ProductSummarySKUName` is a VTEX Component that renders the selected SKU's name.
-This Component can be imported and used by any VTEX App.
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+# Product Summary SKU Name
+
+The _Product Summary SKU Name_ is a VTEX Component that renders the selected SKU's name.
 
 :loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
 
-## Table of Contents
-- [Usage](#usage)
-  - [Blocks API](#blocks-api)
-  - [Configuration](#configuration)
-  - [Styles API](#styles-api)
-
-## Usage
+## Configuration
 
 You should follow the usage instruction in the main [README](https://github.com/vtex-apps/product-summary/blob/master/README.md#usage).
 
-Then, add `product-summary-sku-name` block into your app theme, as we do in our [Product Summary app](https://github.com/vtex-apps/product-summary/blob/master/store/blocks.json).
+Then, add `product-summary-sku-name` block into your app theme as children of `product-summary.shelf`, as we do in our [Product Summary app](https://github.com/vtex-apps/product-summary/blob/master/store/blocks.json).
 
-### Blocks API
-
-This component has an interface that describes which rules must be implemented by a block when you want to use the `ProductSummarySKUName`.
-
-```json
-  "product-summary-sku-name": {
-    "component": "ProductSummarySKUName"
-  }
+```diff
+   "product-summary.shelf": {
+    "children": [
+      "product-summary-image",
+      "product-summary-name",
++     "product-summary-sku-name",
+      "product-summary-attachment-list",
+      "product-summary-space",
+      "product-summary-column#1"
+    ]
+  },
 ```
 
-### Styles API
+## Customization
 
-This app provides some CSS classes as an API for style customization.
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-To use this CSS API, you must add the `styles` builder and create an app styling CSS file.
+| CSS Handles        |
+| ------------------ |
+| `skuNameContainer` |
 
-1. Add the `styles` builder to your `manifest.json`:
+## Contributors ✨
 
-```json
-  "builders": {
-    "styles": "1.x"
-  }
-```
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
-2. Create a file called `vtex.product-summary.css` inside the `styles/css` folder. Add your custom styles:
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
 
-```css
-.skuNameContainer {
-  margin-top: 10px;
-}
-```
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
-#### CSS Handles
-
-| CSS Handles   | Description                                          | Component Source                     |
-| ------------ | ---------------------------------------------------- | ------------------------------------ |
-| `skuNameContainer` | The main container of name | [index](/react/ProductSummarySKUName.tsx) |
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/ProductSummarySKUName.md
+++ b/docs/ProductSummarySKUName.md
@@ -1,0 +1,58 @@
+# Product Summary Name
+
+## Description
+
+`ProductSummarySKUName` is a VTEX Component that renders the selected SKU's name.
+This Component can be imported and used by any VTEX App.
+
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
+
+## Table of Contents
+- [Usage](#usage)
+  - [Blocks API](#blocks-api)
+  - [Configuration](#configuration)
+  - [Styles API](#styles-api)
+
+## Usage
+
+You should follow the usage instruction in the main [README](https://github.com/vtex-apps/product-summary/blob/master/README.md#usage).
+
+Then, add `product-summary-sku-name` block into your app theme, as we do in our [Product Summary app](https://github.com/vtex-apps/product-summary/blob/master/store/blocks.json).
+
+### Blocks API
+
+This component has an interface that describes which rules must be implemented by a block when you want to use the `ProductSummarySKUName`.
+
+```json
+  "product-summary-sku-name": {
+    "component": "ProductSummarySKUName"
+  }
+```
+
+### Styles API
+
+This app provides some CSS classes as an API for style customization.
+
+To use this CSS API, you must add the `styles` builder and create an app styling CSS file.
+
+1. Add the `styles` builder to your `manifest.json`:
+
+```json
+  "builders": {
+    "styles": "1.x"
+  }
+```
+
+2. Create a file called `vtex.product-summary.css` inside the `styles/css` folder. Add your custom styles:
+
+```css
+.skuNameContainer {
+  margin-top: 10px;
+}
+```
+
+#### CSS Handles
+
+| CSS Handles   | Description                                          | Component Source                     |
+| ------------ | ---------------------------------------------------- | ------------------------------------ |
+| `skuNameContainer` | The main container of name | [index](/react/ProductSummarySKUName.tsx) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Now, you are able to use all blocks exported by the `product-summary` app. Check
 | [`product-summary-description`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-description) | Renders the product description. | 
 | [`product-summary-image`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-image) | Renders the product image. | 
 | [`product-summary-name`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-name) | Renders the product name. | 
+| [`product-summary-sku-name`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-sku-name) | Renders the selected sku name. | 
 | `product-summary-price` | ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red) The Product Summary Price block, responsible for rendering the product price, has been deprecated in favor of the [Product Price](https://vtex.io/docs/components/all/vtex.product-price/) app. Although support for this block is still granted, we strongly recommend you to use the Product Price app's blocks instead. | 
 | [`product-summary-sku-selector`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-sku-selector) | Renders the SKU Selector block. | 
 | [`product-specification-badges`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-specification-badges) | Renders badges based on the product specifications. |

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
 
-const CSS_HANDLES = ['skuNameContainer']
+const CSS_HANDLES = ['skuNameContainer'] as const
 
 const ProductSummarySKUName = () => {
   const { product } = useProductSummary()

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+import React from 'react'
+// eslint-disable-next-line no-restricted-imports
+import { path } from 'ramda'
+import { useCssHandles } from 'vtex.css-handles'
+import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
+
+const CSS_HANDLES = ['skuNameContainer']
+
+const ProductSummarySKUName = () => {
+  const { product } = useProductSummary()
+  const handles = useCssHandles(CSS_HANDLES)
+  const skuName: string = path(['sku', 'name'], product) ?? ''
+  const { productName } = product
+
+  if (!skuName || skuName === productName) {
+    return null
+  }
+
+  return (
+    <div
+      className={`${handles.skuNameContainer} flex items-start justify-center pv6`}
+    >
+      {skuName}
+    </div>
+  )
+}
+
+export default ProductSummarySKUName

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 import React from 'react'
-// eslint-disable-next-line no-restricted-imports
-import { path } from 'ramda'
 import { useCssHandles } from 'vtex.css-handles'
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'
 

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { useProductSummary } from 'vtex.product-summary-context/ProductSummaryContext'

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -10,7 +10,7 @@ const CSS_HANDLES = ['skuNameContainer']
 const ProductSummarySKUName = () => {
   const { product } = useProductSummary()
   const handles = useCssHandles(CSS_HANDLES)
-  const skuName: string = path(['sku', 'name'], product) ?? ''
+  const skuName: string = product?.sku?.name ?? ''
   const { productName } = product
 
   if (!skuName || skuName === productName) {

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -15,9 +15,7 @@ const ProductSummarySKUName = () => {
   }
 
   return (
-    <div
-      className={`${handles.skuNameContainer} flex items-start justify-center pv6`}
-    >
+    <div className={handles.skuNameContainer}>
       {skuName}
     </div>
   )

--- a/react/ProductSummarySKUName.tsx
+++ b/react/ProductSummarySKUName.tsx
@@ -14,11 +14,7 @@ const ProductSummarySKUName = () => {
     return null
   }
 
-  return (
-    <div className={handles.skuNameContainer}>
-      {skuName}
-    </div>
-  )
+  return <div className={handles.skuNameContainer}>{skuName}</div>
 }
 
 export default ProductSummarySKUName

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,21 @@
     "@vtex/test-tools": "^0.1.3",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector",
+    "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context",
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
+    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.0/public/@types/vtex.product-context",
+    "vtex.product-list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context",
+    "vtex.product-specification-badges": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.2/public/@types/vtex.product-specification-badges",
+    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.121.0/public/@types/vtex.render-runtime",
+    "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.130.1/public/@types/vtex.store-components",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.71.0/public/_types/react",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.129.0/public/@types/vtex.styleguide"
   },
   "vtexScriptsOverride": {
     "srcPath": "."

--- a/react/package.json
+++ b/react/package.json
@@ -21,21 +21,7 @@
     "@vtex/test-tools": "^0.1.3",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
-    "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.4/public/@types/vtex.device-detector",
-    "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context",
-    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types",
-    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.0/public/@types/vtex.product-context",
-    "vtex.product-list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context",
-    "vtex.product-specification-badges": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.1/public/@types/vtex.product-specification-badges",
-    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.4.1/public/@types/vtex.product-summary-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime",
-    "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.2.0/public/_types/react",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.119.8/public/_types/react",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.64.0/public/_types/react",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide"
+    "typescript": "3.8.3"
   },
   "vtexScriptsOverride": {
     "srcPath": "."

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4457,6 +4457,62 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
+
+"vtex.device-detector@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector":
+  version "0.2.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.5/public/@types/vtex.device-detector#edbc992ee63c728664e67bd165af56cedd17a6c4"
+
+"vtex.list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context":
+  version "0.1.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context#c8ac9fc35b3f82b782562fa96e487ffc5ff02ca6"
+
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
+  version "0.7.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
+
+"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager":
+  version "1.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.4.0/public/@types/vtex.pixel-manager#f636047e354d65f4d7691c81e799c6458407bec0"
+
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.0/public/@types/vtex.product-context":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.0/public/@types/vtex.product-context#1f871c3e155d4ec7f71ee03765bcc85135765fe5"
+
+"vtex.product-list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context#830570426aa5e0286e2510ac04ddca054522e4fc"
+
+"vtex.product-specification-badges@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.2/public/@types/vtex.product-specification-badges":
+  version "0.1.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.2/public/@types/vtex.product-specification-badges#5bf4e90216e7d9a6c2205d7c00ee8ef4da1ddb52"
+
+"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.5.0/public/@types/vtex.product-summary-context#51e4062e3d6f39a1b376416a75fd7bf296c1c085"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.121.0/public/@types/vtex.render-runtime":
+  version "8.121.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.121.0/public/@types/vtex.render-runtime#2d5cfba8888df1844a808828b87e5331ab5baa59"
+
+"vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.130.1/public/@types/vtex.store-components":
+  version "3.130.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.130.1/public/@types/vtex.store-components#a33eb3117d10bd022105c5f1e1afa028ea8c9552"
+
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.71.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.71.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.129.0/public/@types/vtex.styleguide":
+  version "9.129.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.129.0/public/@types/vtex.styleguide#916e6fbd7f14585c9e07e040d41d8966860affba"
+
 w3c-hr-time@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4457,62 +4457,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
-  version "0.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
-
-"vtex.device-detector@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.4/public/@types/vtex.device-detector":
-  version "0.2.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.4/public/@types/vtex.device-detector#bdf7ba78ba34e4ada63cca2bdf56e1674da068b9"
-
-"vtex.list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context":
-  version "0.1.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.1.1/public/@types/vtex.list-context#c8ac9fc35b3f82b782562fa96e487ffc5ff02ca6"
-
-"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types":
-  version "0.7.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.1/public/@types/vtex.native-types#a197484a2fdcee5c61a6d20ad6c994faa58380f5"
-
-"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager":
-  version "1.1.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager#96907e17f4e5c584162a47dc425cb5afb2267d00"
-
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.0/public/@types/vtex.product-context":
-  version "0.8.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.0/public/@types/vtex.product-context#02fb5b64676fd7c7ffa0c5531ff5fe8a39e57a54"
-
-"vtex.product-list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context":
-  version "0.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.3.0/public/@types/vtex.product-list-context#830570426aa5e0286e2510ac04ddca054522e4fc"
-
-"vtex.product-specification-badges@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.1/public/@types/vtex.product-specification-badges":
-  version "0.1.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.1.1/public/@types/vtex.product-specification-badges#ed146564c6815cc16dfba6ab547e217dd4c3cfe5"
-
-"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.4.1/public/@types/vtex.product-summary-context":
-  version "0.4.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.4.1/public/@types/vtex.product-summary-context#d79273a55b760faebaddad774ce5460db2274009"
-
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime":
-  version "8.111.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime#01b2ce53d1aa2a974f5229c61bd9c83b43a86d76"
-
-"vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.2.0/public/_types/react":
-  version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.2.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
-
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.119.8/public/_types/react":
-  version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.119.8/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
-
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.64.0/public/_types/react":
-  version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.64.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
-
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide":
-  version "9.124.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide#23f1937bebae169c1d110594a4af3cc3ef05c601"
-
 w3c-hr-time@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -54,6 +54,9 @@
   "product-summary-name": {
     "component": "ProductSummaryName"
   },
+  "product-summary-sku-name": {
+    "component": "ProductSummarySKUName"
+  },
   "product-summary-brand": {
     "component": "ProductSummaryBrand"
   },


### PR DESCRIPTION
#### What problem is this solving?
The client wants to add the Product's SKU name to the shelf, current solution is to load the product-name component set the property to showSku and via CSS change the aspects of it generating extra useless information on the page.

<!--- What is the motivation and context for this change? -->

#### How to test it?
Add `product-summary-sku-name` to the `product-summary.shelf`

```diff
"product-summary.shelf": {
    "children": [
      "product-summary-add-to-list-button",
      "stack-layout#shelf-image-flag",
      "product-summary-name",
+    "product-summary-sku-name",
      "product-rating-inline",
      "product-location-availability",
      "product-summary-price",
      "product-summary-sku-selector",
      "add-to-cart-button"
    ],
```
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://wender--eriksbikeshop.myvtex.com/Cycling/Bicycles/Road)

#### Screenshots or example usage:
![Screen Shot 2020-09-22 at 16 51 15](https://user-images.githubusercontent.com/24723/93931012-9f1e3c00-fcf4-11ea-9def-a4a37bfa502d.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
