### PR TITLE
Add ProductSummary prop to ProductSummaryList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductSummary` prop to `ProductSummaryList`.
 
 ## [2.60.0] - 2020-09-24
 ### Added

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -47,7 +47,7 @@ function getOrdinationProp(attribute) {
   )
 }
 
-const ProductSummaryList = ({ children, ...props }) => {
+function ProductSummaryList(props) {
   const {
     category = '',
     collection,
@@ -57,6 +57,8 @@ const ProductSummaryList = ({ children, ...props }) => {
     maxItems = 10,
     skusFilter,
     installmentCriteria,
+    children,
+    ProductSummary,
   } = props
 
   const { data, loading, error } = useQuery(productsQuery, {
@@ -84,7 +86,10 @@ const ProductSummaryList = ({ children, ...props }) => {
   }
 
   return (
-    <ProductSummaryListWithoutQuery products={products}>
+    <ProductSummaryListWithoutQuery
+      products={products}
+      ProductSummary={ProductSummary}
+    >
       {children}
     </ProductSummaryListWithoutQuery>
   )

--- a/react/ProductSummaryListWithoutQuery.js
+++ b/react/ProductSummaryListWithoutQuery.js
@@ -8,7 +8,7 @@ import ProductListEventCaller from './components/ProductListEventCaller'
 
 const { ProductListProvider } = ProductListContext
 
-const List = ({ children, products }) => {
+function List({ children, products, ProductSummary }) {
   const { list } = useListContext()
   const { treePath } = useTreePath()
 
@@ -17,6 +17,10 @@ const List = ({ children, products }) => {
       products &&
       products.map((product) => {
         const normalizedProduct = mapCatalogProductToProductSummary(product)
+
+        if (typeof ProductSummary === 'function') {
+          return <ProductSummary product={normalizedProduct} />
+        }
 
         return (
           <ExtensionPoint
@@ -29,7 +33,7 @@ const List = ({ children, products }) => {
       })
 
     return list.concat(componentList)
-  }, [products, treePath, list])
+  }, [products, treePath, list, ProductSummary])
 
   return (
     <ListContextProvider list={newListContextValue}>
@@ -38,10 +42,16 @@ const List = ({ children, products }) => {
   )
 }
 
-const ProductSummaryListWithoutQuery = ({ children, products }) => {
+const ProductSummaryListWithoutQuery = ({
+  children,
+  products,
+  ProductSummary,
+}) => {
   return (
     <ProductListProvider>
-      <List products={products}>{children}</List>
+      <List products={products} ProductSummary={ProductSummary}>
+        {children}
+      </List>
       <ProductListEventCaller />
     </ProductListProvider>
   )


### PR DESCRIPTION
#### What problem is this solving?

Adding a prop `ProductSummary` to `ProductSummaryList` to be possible to use this component inside of another component'.

I didn't add any documentation about this because it might be confusing of how to use this component since you can pass the block via `blocks`  attribute of the interface

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://klynger--marinbrasil.myvtex.com/)

#### Screenshots or example usage:

This is my code

```typescript
function ProductSummary(props: SummaryProps) {
  const { product } = props

  return (
    <ProductSummaryCustom product={product}>
      <StackLayout>
        <ProductSummaryImage />
        <ProductSummarySpecificationBadges />
      </StackLayout>
      <ProductSummaryName />
      <RateStars />
      <ProductPrice />
      <AddToCartButton />
    </ProductSummaryCustom>
  )
}

function Shelf(props: ShelfProps) {
  const {
    orderBy,
    category,
    maxItems,
    collection,
    hideUnavailableItems,
    specificationFilters,
  } = props

  return (
    <ProductSummaryList
      orderBy={orderBy}
      maxItems={maxItems}
      category={category}
      collection={collection}
      ProductSummary={ProductSummary}
      hideUnavailableItems={hideUnavailableItems}
      specificationFilters={specificationFilters}
    >
      <SliderLayout />
    </ProductSummaryList>
  )
}
```

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

Slot because I'm adding a slot... did you get it? 😅 
![](https://media.giphy.com/media/kA158Gup0eSpG/giphy.gif)
