### PR TITLE
Fix orderBy default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Default value for `orderBy` query variable, performed by the `ProductSummaryList` component.
 
 ## [2.63.0] - 2020-11-06
 ### Changed

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -6,6 +6,10 @@ import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
 import ProductSummaryListWithoutQuery from './ProductSummaryListWithoutQuery'
 
 const ORDER_BY_OPTIONS = {
+  DEFAULT: {
+    name: 'admin/editor.productSummaryList.orderType.default',
+    value: '',
+  },
   RELEVANCE: {
     name: 'admin/editor.productSummaryList.orderType.relevance',
     value: 'OrderByScoreDESC',
@@ -53,7 +57,7 @@ function ProductSummaryList(props) {
     category = '',
     collection,
     hideUnavailableItems = false,
-    orderBy = ORDER_BY_OPTIONS.TOP_SALE_DESC.value,
+    orderBy = ORDER_BY_OPTIONS.DEFAULT.value,
     specificationFilters = [],
     maxItems = 10,
     skusFilter,
@@ -139,7 +143,7 @@ ProductSummaryList.getSchema = () => ({
       type: 'string',
       enum: getOrdinationProp('value'),
       enumNames: getOrdinationProp('name'),
-      default: ORDER_BY_OPTIONS.TOP_SALE_DESC.value,
+      default: ORDER_BY_OPTIONS.DEFAULT.value,
       isLayout: false,
     },
     hideUnavailableItems: {

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -53,7 +53,7 @@ function ProductSummaryList(props) {
     category = '',
     collection,
     hideUnavailableItems = false,
-    orderBy = ORDER_BY_OPTIONS.DEFAULT.value,
+    orderBy = ORDER_BY_OPTIONS.RELEVANCE.value,
     specificationFilters = [],
     maxItems = 10,
     skusFilter,

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -6,13 +6,9 @@ import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
 import ProductSummaryListWithoutQuery from './ProductSummaryListWithoutQuery'
 
 const ORDER_BY_OPTIONS = {
-  DEFAULT: {
-    name: 'admin/editor.productSummaryList.orderType.default',
-    value: '',
-  },
   RELEVANCE: {
     name: 'admin/editor.productSummaryList.orderType.relevance',
-    value: 'OrderByScoreDESC',
+    value: '',
   },
   TOP_SALE_DESC: {
     name: 'admin/editor.productSummaryList.orderType.sales',
@@ -143,7 +139,7 @@ ProductSummaryList.getSchema = () => ({
       type: 'string',
       enum: getOrdinationProp('value'),
       enumNames: getOrdinationProp('name'),
-      default: ORDER_BY_OPTIONS.DEFAULT.value,
+      default: ORDER_BY_OPTIONS.RELEVANCE.value,
       isLayout: false,
     },
     hideUnavailableItems: {


### PR DESCRIPTION
#### What problem is this solving?

This enables products to be displayed in the way they were sorted inside a collection. Currently, this is not possible. It also changes the default behavior of the `Relevance` orderBy option, which now will just send an empty string to the API and use the default ordering logic our Seach API uses.

#### How to test it?

[Workspace](https://victormiranda--storecomponents.myvtex.com/)

#### Screenshots or example usage:

This is not really a visual change, I don't know how to illustrate it 😢 

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
