### PR TITLE
Adding support for custom placeholder images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ProductSummaryImage` can receive a custom placeholder image by using the `placeholder` prop.
+- `ProductSummaryImage` can now receive a custom placeholder image by using the `placeholder` prop.
 
 ## [2.63.1] - 2020-11-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ProductSummaryImage` can receive a custom placeholder image by using the `placeholder` prop.
 
 ## [2.63.1] - 2020-11-13
 ### Changed

--- a/docs/ProductSummaryImage.md
+++ b/docs/ProductSummaryImage.md
@@ -39,6 +39,7 @@
 | `badgeText` | `string` | Text displayed on the discount badge (in case the badge is configured to be displayed on the image). | `undefined` |
 | `showCollections` | `boolean` | Whether collection badges (if there are any) will be displayed (`true`) or not (`false`). | `false` |
 | `displayMode` | `enum` | Defines the Product Summary Image display mode. Possible values are: `normal` and `inline`. | `normal` |
+| `placeholder` | `string` | Defines the Product Summary Image placeholder image. | `undefined` |
 | `mainImageLabel` | `string` | Text value that matches the value defined in the `imageLabel` field from the admin's Catalog. Once matched, it defines which product image will be the main image displayed in the Product Summary component. If you set a label and no match is found, the main image of the product will be shown instead. | `undefined`|
 | `hoverImageLabel` | `String` | Text value that matches the value defined in the `imageLabel` field from the admin's Catalog. Once matched, it defines which product image will be displayed when the user is hovering. If you set a label and no match is found, no image will be displayed during the hover. | `undefined` |
 | `width` | `object` | Defines the Product Summary Image width. | `undefined` |

--- a/react/__tests__/ProductSummaryImage.test.js
+++ b/react/__tests__/ProductSummaryImage.test.js
@@ -100,4 +100,49 @@ describe('<ProductImage /> component', () => {
 
     expect(svgElements).toHaveLength(1)
   })
+
+  it('should render custom placeholder img', () => {
+    const rawProduct = {
+      productId: '123456789',
+      linkText: 'linkText',
+      productName: 'productName',
+      items: [
+        {
+          itemId: '1',
+          name: 'item 1',
+          sellers: [
+            {
+              sellerId: '1',
+              commertialOffer: {
+                AvailableQuantity: 0,
+                Price: 10,
+                ListPrice: 7,
+              },
+            },
+          ],
+          images: [],
+        },
+      ],
+      productClusters: [
+        {
+          name: 'name',
+        },
+      ],
+      quantity: 1,
+    }
+    const placeholder = 'placeholder-image-url'
+
+    const product = ProductSummary.mapCatalogProductToProductSummary(rawProduct)
+
+    const { container } = render(
+      <ProductSummary product={product}>
+        <ProductImage placeholder={placeholder} />
+      </ProductSummary>
+    )
+
+    const imgElements = container.getElementsByTagName('img')
+
+    expect(imgElements).toHaveLength(1)
+    expect(imgElements[0].src.includes(placeholder)).toBeTruthy()
+  })
 })

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -138,6 +138,7 @@ const ProductImageContent = ({
   mainImageLabel,
   hoverImageLabel,
   showCollections,
+  placeholder,
   width: widthProp,
   height: heightProp,
   aspectRatio,
@@ -172,7 +173,7 @@ const ProductImageContent = ({
 
   let skuImageUrl = pathOr('', ['image', 'imageUrl'], sku)
 
-  if (!skuImageUrl || hasError) {
+  if (!placeholder && (!skuImageUrl || hasError)) {
     return (
       <div className={containerClassname}>
         <ImagePlaceholder cssHandle={handles.productImage} />
@@ -220,7 +221,7 @@ const ProductImageContent = ({
   const img = (
     <div className={containerClassname}>
       <Image
-        src={skuImageUrl}
+        src={!skuImageUrl || hasError ? placeholder : skuImageUrl}
         width={width}
         height={height}
         aspectRatio={aspectRatio}
@@ -254,6 +255,7 @@ const ProductImage = ({
   mainImageLabel,
   hoverImageLabel,
   showCollections,
+  placeholder,
   width: widthProp,
   height: heightProp,
   aspectRatio: aspectRatioProp,
@@ -295,6 +297,7 @@ const ProductImage = ({
         mainImageLabel={mainImageLabel}
         hoverImageLabel={hoverImageLabel}
         showCollections={showCollections}
+        placeholder={placeholder}
       />
     </div>
   )
@@ -311,6 +314,7 @@ ProductImage.propTypes = {
   displayMode: PropTypes.oneOf(['normal', 'inline']),
   hoverImageLabel: PropTypes.string,
   mainImageLabel: PropTypes.string,
+  placeholder: PropTypes.string,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
 }

--- a/react/components/ProductSummaryImage/ProductImage.js
+++ b/react/components/ProductSummaryImage/ProductImage.js
@@ -173,7 +173,9 @@ const ProductImageContent = ({
 
   let skuImageUrl = pathOr('', ['image', 'imageUrl'], sku)
 
-  if (!placeholder && (!skuImageUrl || hasError)) {
+  const shouldDisplayPlaceholder = !skuImageUrl || hasError
+
+  if (!placeholder && shouldDisplayPlaceholder) {
     return (
       <div className={containerClassname}>
         <ImagePlaceholder cssHandle={handles.productImage} />
@@ -221,7 +223,7 @@ const ProductImageContent = ({
   const img = (
     <div className={containerClassname}>
       <Image
-        src={!skuImageUrl || hasError ? placeholder : skuImageUrl}
+        src={shouldDisplayPlaceholder ? placeholder : skuImageUrl}
         width={width}
         height={height}
         aspectRatio={aspectRatio}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds support for custom placeholder images on ProductSummaryImage.

#### How to test it?

<s>confia no pai</s> It seems there's no way to create a workspace in which the products are always imageless. I've added some unit test to ease that problem. I've manually disabled product images in the workspace below so it shows a custom placeholder image.

[Workspace](https://icaroimageplaceholder2--storecomponents.myvtex.com/)

#### Screenshots or example usage:
This is a custom placeholder image
<img width="263" alt="Screen Shot 2020-11-17 at 12 53 25 PM" src="https://user-images.githubusercontent.com/8127610/99412822-e6c7db00-28d3-11eb-8910-eb72d1cb1ff2.png">

#### Related to

[store-components#880](https://github.com/vtex-apps/store-components/pull/880)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/tKIt3zenrB7CgdRlI2/giphy.gif)
