### PR TITLE
Add action on product click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `actionOnProductClick` prop to `ProductSummaryList`.
+
 ## [2.64.0] - 2020-11-30
 ### Added
 - `ProductSummaryImage` can now receive a custom placeholder image by using the `placeholder` prop.

--- a/react/ProductSummaryList.js
+++ b/react/ProductSummaryList.js
@@ -60,6 +60,7 @@ function ProductSummaryList(props) {
     installmentCriteria,
     children,
     ProductSummary,
+    actionOnProductClick,
   } = props
 
   const { data, loading, error } = useQuery(productsQuery, {
@@ -90,6 +91,7 @@ function ProductSummaryList(props) {
     <ProductSummaryListWithoutQuery
       products={products}
       ProductSummary={ProductSummary}
+      actionOnProductClick={actionOnProductClick}
     >
       <ProductListStructuredData products={products} />
       {children}

--- a/react/ProductSummaryListWithoutQuery.js
+++ b/react/ProductSummaryListWithoutQuery.js
@@ -8,7 +8,7 @@ import ProductListEventCaller from './components/ProductListEventCaller'
 
 const { ProductListProvider } = ProductListContext
 
-function List({ children, products, ProductSummary }) {
+function List({ children, products, ProductSummary, actionOnProductClick }) {
   const { list } = useListContext()
   const { treePath } = useTreePath()
 
@@ -18,8 +18,19 @@ function List({ children, products, ProductSummary }) {
       products.map((product) => {
         const normalizedProduct = mapCatalogProductToProductSummary(product)
 
+        const handleOnClick = () => {
+          if (typeof actionOnProductClick === 'function') {
+            actionOnProductClick(normalizedProduct)
+          }
+        }
+
         if (typeof ProductSummary === 'function') {
-          return <ProductSummary product={normalizedProduct} />
+          return (
+            <ProductSummary
+              product={normalizedProduct}
+              actionOnClick={handleOnClick}
+            />
+          )
         }
 
         return (
@@ -28,12 +39,13 @@ function List({ children, products, ProductSummary }) {
             key={product.id}
             treePath={treePath}
             product={normalizedProduct}
+            actionOnClick={handleOnClick}
           />
         )
       })
 
     return list.concat(componentList)
-  }, [products, treePath, list, ProductSummary])
+  }, [products, treePath, list, ProductSummary, actionOnProductClick])
 
   return (
     <ListContextProvider list={newListContextValue}>
@@ -46,10 +58,15 @@ const ProductSummaryListWithoutQuery = ({
   children,
   products,
   ProductSummary,
+  actionOnProductClick,
 }) => {
   return (
     <ProductListProvider>
-      <List products={products} ProductSummary={ProductSummary}>
+      <List
+        products={products}
+        ProductSummary={ProductSummary}
+        actionOnProductClick={actionOnProductClick}
+      >
         {children}
       </List>
       <ProductListEventCaller />


### PR DESCRIPTION
#### What problem is this solving?
with this prop, it is possible to perform an action when clicking on a product that is within a list. for example, for the new recommendation shelves, we’d like to trigger an event whenever the user clicked on a product in the shelf.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

- [Workspace](https://rec--storecomponents.myvtex.com/apparel---accessories/)
- go to the bottom of the page
- click on a product in the shelf
- in the `window.pixelManagerEvents` should have a `shelf` event of type `productClick`


#### Screenshots or example usage:
![event](https://user-images.githubusercontent.com/20840671/100137791-c23ba800-2e6b-11eb-82bd-3e3e3c7a55d6.gif)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.


<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
