### PR TITLE
Use first available seller instead of always using the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use first available seller instead of always using the first.
 
 ## [2.66.1] - 2020-12-14
 ### Fixed

--- a/react/__mocks__/vtex.product-context.js
+++ b/react/__mocks__/vtex.product-context.js
@@ -9,3 +9,5 @@ export const ProductContextProvider = ({ product, query, ...rest }) => {
 }
 
 export const useProduct = () => useContext(ProductContext)
+
+export const useProductDispatch = () => null

--- a/react/__mocks__/vtex.product-context/ProductDispatchContext.js
+++ b/react/__mocks__/vtex.product-context/ProductDispatchContext.js
@@ -1,1 +1,0 @@
-export const useProductDispatch = () => null

--- a/react/components/ProductSummarySKUSelector/index.tsx
+++ b/react/components/ProductSummarySKUSelector/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-// eslint-disable-next-line no-restricted-imports
-import { head } from 'ramda'
 import { SKUSelector } from 'vtex.store-components'
 import { useCssHandles } from 'vtex.css-handles'
 import {
   useProductSummaryDispatch,
   useProductSummary,
 } from 'vtex.product-summary-context/ProductSummaryContext'
+
+import { getFirstAvailableSeller } from '../../modules/seller'
 
 const CSS_HANDLES = ['SKUSelectorContainer']
 
@@ -34,8 +34,9 @@ function ProductSummarySKUSelector(props: any) {
 
     const sku = {
       ...selectedItem,
-      image: head(selectedItem.images),
-      seller: head(selectedItem.sellers),
+      image: selectedItem.images[0],
+      seller:
+        getFirstAvailableSeller(selectedItem.sellers) ?? selectedItem.seller[0],
     }
 
     const newProduct = {

--- a/react/modules/seller.ts
+++ b/react/modules/seller.ts
@@ -1,0 +1,13 @@
+import { ProductTypes } from 'vtex.product-context'
+
+export function getFirstAvailableSeller(sellers?: ProductTypes.Seller[]) {
+  if (!sellers || sellers.length === 0) {
+    return
+  }
+
+  const availableSeller = sellers.find(
+    (seller) => seller.commertialOffer.AvailableQuantity !== 0
+  )
+
+  return availableSeller
+}

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -1,3 +1,5 @@
+import { getFirstAvailableSeller } from '../modules/seller'
+
 export const DEFAULT_WIDTH = 'auto'
 export const DEFAULT_HEIGHT = 'auto'
 export const MAX_WIDTH = 3000
@@ -92,7 +94,11 @@ export function mapCatalogProductToProductSummary(
   const sku = items.find(findAvailableProduct) || items[0]
 
   if (sku) {
-    const [seller = defaultSeller] = sku?.sellers ?? []
+    const seller =
+      getFirstAvailableSeller(sku?.sellers) ??
+      sku?.sellers?.[0] ??
+      defaultSeller
+
     const [referenceId = defaultReference] = sku?.referenceId ?? []
     const catalogImages = sku?.images ?? []
     const normalizedImages = catalogImages.map(


### PR DESCRIPTION
#### What problem is this solving?

Change hardcoded seller selection of using the first to the first available seller.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

https://brenovtex--motorolauk.myvtex.com/

https://seller--storecomponents.myvtex.com/


#### Screenshots or example usage:


Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/102381637-3c150c00-3fa8-11eb-89ee-f1a25a6c072a.png) | ![image](https://user-images.githubusercontent.com/284515/102381585-2c95c300-3fa8-11eb-9899-6051f9e835c9.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
