### PR TITLE
Applying modifiers to overridden classes on sku-selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Apply modifiers to overridden classes on sku-selector
 
 ## [2.68.0] - 2020-12-18
 ### Added

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -182,7 +182,7 @@ interface Props {
    * @default "default"
    */
   priceBehavior?: 'async' | 'default'
-  classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
 function ProductSummaryWrapper({

--- a/react/ProductSummarySKUSelector.tsx
+++ b/react/ProductSummarySKUSelector.tsx
@@ -66,68 +66,100 @@ function ProductSummarySKUSelector(props: Props) {
   const skuSelectorClasses = useCustomClasses(
     () => ({
       frameAround: [
-        handles.frameAround,
-        'vtex-store-components-3-x-frameAround',
+        {
+          name: `${handles.frameAround} vtex-store-components-3-x-frameAround`,
+          applyModifiers: true,
+        },
       ],
       seeMoreButton: [
-        handles.seeMoreButton,
-        'vtex-store-components-3-x-seeMoreButton',
+        {
+          name: `${handles.seeMoreButton} vtex-store-components-3-x-seeMoreButton`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorContainer: [
-        handles.skuSelectorContainer,
-        'vtex-store-components-3-x-skuSelectorContainer',
+        {
+          name: `${handles.skuSelectorContainer} vtex-store-components-3-x-skuSelectorContainer`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorInternalBox: [
-        handles.skuSelectorInternalBox,
-        'vtex-store-components-3-x-skuSelectorInternalBox',
+        {
+          name: `${handles.skuSelectorInternalBox} vtex-store-components-3-x-skuSelectorInternalBox`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorItemImageValue: [
-        handles.skuSelectorItemImageValue,
-        'vtex-store-components-3-x-skuSelectorItemImageValue',
+        {
+          name: `${handles.skuSelectorItemImageValue} vtex-store-components-3-x-skuSelectorItemImageValue`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorItemImage: [
-        handles.skuSelectorItemImage,
-        'vtex-store-components-3-x-skuSelectorItemImage',
+        {
+          name: `${handles.skuSelectorItemImage} vtex-store-components-3-x-skuSelectorItemImage`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorItemTextValue: [
-        handles.skuSelectorItemTextValue,
-        'vtex-store-components-3-x-skuSelectorItemTextValue',
+        {
+          name: `${handles.skuSelectorItemTextValue} vtex-store-components-3-x-skuSelectorItemTextValue`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorItem: [
-        handles.skuSelectorItem,
-        'vtex-store-components-3-x-skuSelectorItem',
+        {
+          name: `${handles.skuSelectorItem} vtex-store-components-3-x-skuSelectorItem`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorNameContainer: [
-        handles.skuSelectorNameContainer,
-        'vtex-store-components-3-x-skuSelectorNameContainer',
+        {
+          name: `${handles.skuSelectorNameContainer} vtex-store-components-3-x-skuSelectorNameContainer`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorNameSeparator: [
-        handles.skuSelectorNameSeparator,
-        'vtex-store-components-3-x-skuSelectorNameSeparator',
+        {
+          name: `${handles.skuSelectorNameSeparator} vtex-store-components-3-x-skuSelectorNameSeparator`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorName: [
-        handles.skuSelectorName,
-        'vtex-store-components-3-x-skuSelectorName',
+        {
+          name: `${handles.skuSelectorName} vtex-store-components-3-x-skuSelectorName`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorOptionsList: [
-        handles.skuSelectorOptionsList,
-        'vtex-store-components-3-x-skuSelectorOptionsList',
+        {
+          name: `${handles.skuSelectorOptionsList} vtex-store-components-3-x-skuSelectorOptionsList`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorSelectorImageValue: [
-        handles.skuSelectorSelectorImageValue,
-        'vtex-store-components-3-x-skuSelectorSelectorImageValue',
+        {
+          name: `${handles.skuSelectorSelectorImageValue} vtex-store-components-3-x-skuSelectorSelectorImageValue`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorSubcontainer: [
-        handles.skuSelectorSubcontainer,
-        'vtex-store-components-3-x-skuSelectorSubcontainer',
+        {
+          name: `${handles.skuSelectorSubcontainer} vtex-store-components-3-x-skuSelectorSubcontainer`,
+          applyModifiers: true,
+        },
       ],
       skuSelectorTextContainer: [
-        handles.skuSelectorTextContainer,
-        'vtex-store-components-3-x-skuSelectorTextContainer',
+        {
+          name: `${handles.skuSelectorTextContainer} vtex-store-components-3-x-skuSelectorTextContainer`,
+          applyModifiers: true,
+        },
       ],
       valueWrapper: [
-        handles.valueWrapper,
-        'vtex-store-components-3-x-valueWrapper',
+        {
+          name: `${handles.valueWrapper} vtex-store-components-3-x-valueWrapper`,
+          applyModifiers: true,
+        },
       ],
     }),
     [handles]


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes ProductSummarySKUSelector compatibility issues with SKUSelector from `store-components` new css handles API by allowing SKUSelector to apply modifiers to the overridden handles.

#### How to test it?

This workspace was broken when the new version of `store-components` was installed. It shouldn't be broken anymore

[Workspace](https://icarovtex--samsungbr.myvtex.com/mobile/smartphone?order=OrderByPriceDESC)

#### Related to / Depends on

Related to [store-components#903](https://github.com/vtex-apps/store-components/pull/903)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/3o7P4F86TAI9Kz7XYk/giphy.gif)
