### PR TITLE
Fix error of missing key in React list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- React key error in lists.
 
 ## [2.68.1] - 2020-12-21
 ### Fixed

--- a/react/ProductSummaryListWithoutQuery.tsx
+++ b/react/ProductSummaryListWithoutQuery.tsx
@@ -34,7 +34,12 @@ function List({
       const normalizedProduct = mapCatalogProductToProductSummary(product)
 
       if (typeof ProductSummary === 'function') {
-        return <ProductSummary product={normalizedProduct} />
+        return (
+          <ProductSummary
+            key={normalizedProduct.cacheId}
+            product={normalizedProduct}
+          />
+        )
       }
 
       const handleOnClick = () => {
@@ -46,7 +51,7 @@ function List({
       return (
         <ExtensionPoint
           id="product-summary"
-          key={product.id}
+          key={product.cacheId}
           treePath={treePath}
           product={normalizedProduct}
           actionOnClick={handleOnClick}


### PR DESCRIPTION
#### What problem is this solving?

Fix the following error when using slider-layout + product-list
https://old--storeframework.myvtex.com/
![image](https://user-images.githubusercontent.com/284515/103833941-e8568980-5060-11eb-9f4b-b85e7aaa4a23.png)

#### How to test it?

https://summary--storeframework.myvtex.com/

#### Screenshots or example usage:

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/103833980-f99f9600-5060-11eb-8d20-f8db34669c3a.png) | ![image](https://user-images.githubusercontent.com/284515/103834058-2bb0f800-5061-11eb-90af-ead09d2e3a69.png)

#### Describe alternatives you've considered, if any.

n/a

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
