### PR TITLE
Add new CSS handle imageWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New CSS Handle `imageWrapper` in `product-summary-image`.
 
 ## [2.68.2] - 2021-01-12
 ### Fixed

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -22,6 +22,7 @@ const { useProductSummary } = ProductSummaryContext
 
 const CSS_HANDLES = [
   'image',
+  'imageWrapper',
   'imageContainer',
   'product',
   'imagePlaceholder',
@@ -316,9 +317,14 @@ function ProductImage({
     maxHeightProp,
   })
 
-  const imageClassName = classNames(productSummary.imageContainer, {
-    'db w-100 center': displayMode !== 'inline',
-  })
+  const imageClassName = classNames(
+    // legacy class
+    productSummary.imageContainer,
+    handles.imageWrapper,
+    {
+      'db w-100 center': displayMode !== 'inline',
+    }
+  )
 
   const [width, height] = [
     // fallsback to the other remaining value, if not defined


### PR DESCRIPTION
#### What problem is this solving?

Add new CSS handle that was missing in product summary image.

#### How to test it?

https://summary--storeframework.myvtex.com/

#### Screenshots or example usage:

You can see that 2 elements have `imageContainer`. This PR adds a new CSS Handle called `imageWrapper` to target one of those elements.

![image](https://user-images.githubusercontent.com/284515/105741759-75328b80-5f19-11eb-9e24-660fe87851d7.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](put .gif link here - can be found under "advanced" on giphy)
