### PR TITLE
Fix action on click when clicking on the add to cart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `actionOnClick` when clicking on the Add to Cart button.
+
 ## [2.71.0] - 2021-03-29
 ### Added
 - Option to match only a substring when defining the Product Image's label.

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -130,6 +130,7 @@ function ProductSummaryCustom({
   const linkProps = href
     ? {
         to: href,
+        onClickCapture: actionOnClick,
       }
     : {
         page: 'store.product',
@@ -138,6 +139,7 @@ function ProductSummaryCustom({
           id: product?.productId,
         },
         query,
+        onClickCapture: actionOnClick,
       }
 
   return (
@@ -158,11 +160,7 @@ function ProductSummaryCustom({
             style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
             ref={inViewRef}
           >
-            <Link
-              className={linkClasses}
-              {...linkProps}
-              onClick={actionOnClick}
-            >
+            <Link className={linkClasses} {...linkProps}>
               <article className={summaryClasses}>{children}</article>
             </Link>
           </section>


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
When clicking on the add to cart button, the `actionOnClick` was not being called. This is affecting search reports.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--storecomponents.myvtex.com/apparel---accessories/)
- click the add to cart button directly from the search page
- check if the `productClick` event was dispatched on `pixelManagerEvents`

#### Screenshots or example usage:

Before:

https://user-images.githubusercontent.com/20840671/112895395-7451dd80-90b3-11eb-9408-c6d5325d1f2a.mp4

After:

https://user-images.githubusercontent.com/20840671/112895362-6734ee80-90b3-11eb-9c42-d48ef7d929d6.mp4


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
