### PR TITLE
Fix autocomplete when clicking on the add to cart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Autocomplete closing when clicking on the Add to Cart button.
+
 ## [2.71.1] - 2021-04-05
 
 ### Fixed

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -50,6 +50,10 @@ function ProductSummaryCustom({
 
   const productListDispatch = ProductListContext.useProductListDispatch()
 
+  const productListState = ProductListContext.useProductListState()
+  const autocompleteSummary =
+    productListState?.listName === 'autocomplete-result-list'
+
   const inViewRef = useRef<HTMLDivElement | null>(null)
   const onView = useCallback(() => {
     productListDispatch?.({
@@ -130,7 +134,8 @@ function ProductSummaryCustom({
   const linkProps = href
     ? {
         to: href,
-        onClickCapture: actionOnClick,
+        onClick: autocompleteSummary ? actionOnClick : undefined,
+        onClickCapture: autocompleteSummary ? undefined : actionOnClick,
       }
     : {
         page: 'store.product',
@@ -139,7 +144,8 @@ function ProductSummaryCustom({
           id: product?.productId,
         },
         query,
-        onClickCapture: actionOnClick,
+        onClick: autocompleteSummary ? actionOnClick : undefined,
+        onClickCapture: autocompleteSummary ? undefined : actionOnClick,
       }
 
   return (

--- a/react/__mocks__/vtex.product-list-context.js
+++ b/react/__mocks__/vtex.product-list-context.js
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react'
 export const useProductImpression = () => null
 export const ProductListContext = {
   useProductListDispatch: () => null,
+  useProductListState: () => null,
   // eslint-disable-next-line react/display-name
   ProductListProvider: ({ children }) => <Fragment>{children}</Fragment>,
 }


### PR DESCRIPTION
#### What problem is this solving?

The `onClickCapture` used in the product summary was causing the autocomplete to close by clicking the add to cart button directly from the autocomplete, as this was identified as a click on the product.
However, this function is necessary to send events used for the search reports when adding a product to the cart directly from the search page.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Ametller](https://test--ametllerorigen.myvtex.com/)
[Giga](https://testl--gigadigital.myvtex.com/guarana?_q=guarana&map=ft)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->


https://user-images.githubusercontent.com/20840671/113870467-40984700-9788-11eb-87d8-6cec41276558.mp4


https://user-images.githubusercontent.com/20840671/113870484-42faa100-9788-11eb-8549-8a5e66fb9acc.mp4


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
