### PR TITLE
Add class to parent that holds the vtex-product-summary-2-x-item

### DIFF
--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -27,6 +27,7 @@ const CSS_HANDLES = [
   'product',
   'imagePlaceholder',
   'mainImageHovered',
+  'summaryItemContainer',
 ] as const
 
 const MAX_SIZE = 500
@@ -153,6 +154,7 @@ function CollectionWrapper({
   showCollections,
   productClusters,
   children,
+  classes,
 }: PropsWithChildren<CollectionWrapperProps>) {
   if (!showCollections || !productClusters || productClusters.length === 0) {
     return <>{children}</>
@@ -160,8 +162,10 @@ function CollectionWrapper({
 
   const collections = productClusters.map((cl) => cl.name)
 
+  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+
   return (
-    <CollectionBadges collectionBadgesText={collections}>
+    <CollectionBadges collectionBadgesText={collections} className={handles.summaryItemContainer}>
       {children}
     </CollectionBadges>
   )


### PR DESCRIPTION
**What problem is this solving?**
The block is encapsulated by a div with generic classes (_inline-flex justify-end absolute w-100 bottom-0 left-0_) which makes it impossible to apply styling... By applying cssHandles to this div we will now be able to position it as needed.


**Add in ProductSummaryImage.tsx**
```
Line 23:
const CSS_HANDLES = [
  ...
  'summaryItemContainer',
] as const

-

Line 157: 
function CollectionWrapper({
  ...
  classes,

-

Line 165: const { handles } = useCssHandles(CSS_HANDLES, { classes })

-

Line 168:
<CollectionBadges collectionBadgesText={collections} className={handles.summaryItemContainer}>
```


**A small example**

![Captura de tela de 2021-05-30 13-45-32](https://user-images.githubusercontent.com/32168339/120112935-7507fe00-c14e-11eb-8cb7-3892610c31d5.png)


**How does this PR make you feel? 🔗**

![image](https://user-images.githubusercontent.com/32168339/102024084-89a63480-3d6e-11eb-8412-b47509d4d9e2.png)