### PR TITLE
Changing trackListName to default to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+`trackListName` prop now defaults to false
 
 ## [2.73.0] - 2021-06-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-`trackListName` prop now defaults to false
+- `trackListName` prop now defaults to false
 
 ## [2.73.0] - 2021-06-09
 ### Fixed

--- a/docs/ProductSummaryShelf.md
+++ b/docs/ProductSummaryShelf.md
@@ -46,7 +46,7 @@ Product Summary Shelf is the main block exported by the Product Summary app. Thr
 | Prop name        | Type          | Description                | Default value  |
 | :--------------: | :---------: | :--------------------------: | :------------: |
 | `priceBehavior` | `enum` | Whether the component should fetch the most up-to-date price (`async`) or not (`default`). Remember to also set the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s`simulationBehavior` prop to `skip` and use the Product Price's [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price data is being fetched. | `default` |
-| `trackListName` | `boolean` | Whether the component should send the list name through the URL of the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated from. | `true` |
+| `trackListName` | `boolean` | Whether the component should send the list name through the URL of the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated from. | `false` |
 
 ## Customization
 

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -209,7 +209,7 @@ function ProductSummaryWrapper({
   actionOnClick,
   href,
   priceBehavior = 'default',
-  trackListName = true,
+  trackListName = false,
   listName,
   position,
   classes,

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -24,7 +24,7 @@
         "trackListName": {
           "title": "admin/editor.productSummary.trackListName.title",
           "type": "boolean",
-          "default": true
+          "default": false
         }
       }
     },


### PR DESCRIPTION
#### What problem is this solving?

This PR solves a problem where marketing campaigns were being broken by the listName querystring that was sent with the product page link.

#### How to test it?

[Workspace](http://icarogtm--storecomponents.myvtex.com)

#### Related to / Depends on

Related to the GTM major
