### PR TITLE
Set a specific SKU in the product context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,14 +3,5 @@
   "root": true,
   "env": {
     "node": true
-  },
-  "overrides": [
-    {
-      "files": ["*.js", "*.jsx"],
-      "parser": "babel-eslint",
-      "parserOptions": {
-        "sourceType": "module"
-      }
-    }
-  ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- The ability to dynamically choose the SKU that will be initially selected
 ## [2.74.1] - 2021-08-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - The ability to dynamically choose the SKU that will be initially selected
+
 ## [2.74.1] - 2021-08-09
 
 ### Changed

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -64,5 +64,4 @@ For `PreferredSKUEnum`:
 | Cheapest        | `PRICE_ASC`       | Selects the cheapest SKU in stock it finds.        |
 | Most Expensive  | `PRICE_DESC`      | Selects the most expensive SKU in stock it finds.  |
 
-⚠️ Keep in mind that the default behaviour for the initially selected SKU, has now changed to a Product (field) specification.  
-If that one doesn't exist, it will use the `preferredSKU` prop. You can read more about it, and how to implement it in [Recipes](https://vtex.io/docs/recipes/all)
+⚠️ There's a way to select which SKU should take preference over this prop. You can create a Product (field) specification and per product assign the value of the desired SKU to be initially selected. Keep in mind that If the specification doesn't exist or if the value is empty, it will use the `preferredSKU` prop as fallback. You can read more about it, and how to implement it in [Recipes](https://vtex.io/docs/recipes/all)

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -38,7 +38,7 @@ This block is used to specify what variation of `product-summary` to be used to 
 | `skusFilter`           | `SkusFilterEnum`                       | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                                    | `"ALL_AVAILABLE"`        |
 | `installmentCriteria`  | `InstallmentCriteriaEnum`              | Control what price to be shown when price has different installments options.                                                                                                                              | `"MAX_WITHOUT_INTEREST"` |
 | `listName`             | `String`                               | Name of the list property on Google Analytics events.                                                                                                                                                      | ``                       |
-| `preferredSKU`         | `PreferredSKUEnum`                     | Controls which SKU will be selected in the summary                                                                                                                                                          | `"FIRST_AVAILABLE"`      |
+| `preferredSKU`         | `PreferredSKUEnum`                     | Controls which SKU will be selected in the summary                                                                                                                                                         | `"FIRST_AVAILABLE"`      |
 
 For `SkusFilterEnum`:
 
@@ -57,10 +57,12 @@ For `InstallmentCriteriaEnum`:
 
 For `PreferredSKUEnum`:
 
-| Name              | Value             | Description                                                                              |
-| ----------------- | ----------------- | ---------------------------------------------------------------------------------------- |
-| First Available   | `FIRST_AVAILABLE` | Selects the first available SKU in stock it finds.                                       |
-| Last Available    | `LAST_AVAILABLE`  | Selects the last available SKU in stock it finds.                                        |
-| Cheapest          | `PRICE_ASC`       | Selects the cheapest SKU in stock it finds.                                              |
-| Most Expensive    | `PRICE_DESC`      | Selects the most expensive SKU in stock it finds.                                        |
-| A specific SKU ID | `SPECIFICATION`   | Selects the desired SKU, see how to do it in [Recipes](https://vtex.io/docs/recipes/all) |
+| Name            | Value             | Description                                        |
+| --------------- | ----------------- | -------------------------------------------------- |
+| First Available | `FIRST_AVAILABLE` | Selects the first available SKU in stock it finds. |
+| Last Available  | `LAST_AVAILABLE`  | Selects the last available SKU in stock it finds.  |
+| Cheapest        | `PRICE_ASC`       | Selects the cheapest SKU in stock it finds.        |
+| Most Expensive  | `PRICE_DESC`      | Selects the most expensive SKU in stock it finds.  |
+
+⚠️ Keep in mind that the default behaviour for the initially selected SKU, has now changed to a Product (field) specification.  
+If that one doesn't exist, it will use the `preferredSKU` prop. You can read more about it, and how to implement it in [Recipes](https://vtex.io/docs/recipes/all)

--- a/docs/ProductSummaryList.md
+++ b/docs/ProductSummaryList.md
@@ -27,29 +27,40 @@ This block is used to specify what variation of `product-summary` to be used to 
 
 `list-context.product-list` is also responsible for performing the GraphQL query that fetches the list of products, so it can receive the following props:
 
-| Prop name              | Type                                   | Description                                                                                                                                                                                                                               | Default value |
-| ---------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `category`             | `String`                               | Category ID of the listed items. For sub-categories, use "/" (e.g. "1/2/3")                                                                                                                                                               | -             |
-| `specificationFilters` | `Array({ id: String, value: String })` | Specification Filters of the listed items.                                                                                                                                                                                                | []            |
-| `collection`           | `String`                               | Filter by collection.                                                                                                                                                                                                                     | -             |
-| `orderBy`              | `Enum`                                 | Ordination type of the items. Possible values: `''`, `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` | `OrderByTopSaleDESC`          |
-| `hideUnavailableItems` | `Boolean`                              | Hides items that are unavailable.                                                                                                                                                                                                         | `false`       |
-| `maxItems` | `Number`                              | Maximum items to be fetched.                                                                                                                                                                                                         | `10`       |
-| `skusFilter`               | `SkusFilterEnum`                 | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                                                                    | `"ALL_AVAILABLE"` |
-| `installmentCriteria`               | `InstallmentCriteriaEnum`                 | Control what price to be shown when price has different installments options.                                                                                                    | `"MAX_WITHOUT_INTEREST"` |
-| `listName`               | `String`                 | Name of the list property on Google Analytics events.                                                                                                    | `` |
+| Prop name              | Type                                   | Description                                                                                                                                                                                                | Default value            |
+| ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `category`             | `String`                               | Category ID of the listed items. For sub-categories, use "/" (e.g. "1/2/3")                                                                                                                                | -                        |
+| `specificationFilters` | `Array({ id: String, value: String })` | Specification Filters of the listed items.                                                                                                                                                                 | []                       |
+| `collection`           | `String`                               | Filter by collection.                                                                                                                                                                                      | -                        |
+| `orderBy`              | `Enum`                                 | Ordination type of the items. Possible values: `''`, `OrderByTopSaleDESC`, `OrderByReleaseDateDESC`, `OrderByBestDiscountDESC`, `OrderByPriceDESC`, `OrderByPriceASC`, `OrderByNameASC`, `OrderByNameDESC` | `OrderByTopSaleDESC`     |
+| `hideUnavailableItems` | `Boolean`                              | Hides items that are unavailable.                                                                                                                                                                          | `false`                  |
+| `maxItems`             | `Number`                               | Maximum items to be fetched.                                                                                                                                                                               | `10`                     |
+| `skusFilter`           | `SkusFilterEnum`                       | Control SKUs returned for each product in the query. The less SKUs needed to be returned, the more performant your shelf query will be.                                                                    | `"ALL_AVAILABLE"`        |
+| `installmentCriteria`  | `InstallmentCriteriaEnum`              | Control what price to be shown when price has different installments options.                                                                                                                              | `"MAX_WITHOUT_INTEREST"` |
+| `listName`             | `String`                               | Name of the list property on Google Analytics events.                                                                                                                                                      | ``                       |
+| `preferredSKU`         | `PreferredSKUEnum`                     | Controls which SKU will be selected in the summary                                                                                                                                                          | `"FIRST_AVAILABLE"`      |
 
 For `SkusFilterEnum`:
 
-| Name | Value | Description |
-| ---- | ----- | ----------- |
+| Name            | Value             | Description                                                                                                                                            |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | First Available | `FIRST_AVAILABLE` | Most performant, ideal if you do not have a SKU selector in your shelf. Will return only the first available SKU for that product in your shelf query. |
-| All Available | `ALL_AVAILABLE` | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance. |
-| All | `ALL` | Returns all SKUs related to that product, least performant option. |
+| All Available   | `ALL_AVAILABLE`   | A bit better performace, will only return SKUs that are available, ideal if you have a SKU selector but still want a better performance.               |
+| All             | `ALL`             | Returns all SKUs related to that product, least performant option.                                                                                     |
 
 For `InstallmentCriteriaEnum`:
 
-| Name | Value | Description |
-| ---- | ----- | ----------- |
-| Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display the maximum installment option with no interest. |
-| Maximum | `MAX_WITH_INTEREST` | Will display the maximum installment option having interest or not. |
+| Name                     | Value                  | Description                                                         |
+| ------------------------ | ---------------------- | ------------------------------------------------------------------- |
+| Maximum without interest | `MAX_WITHOUT_INTEREST` | Will display the maximum installment option with no interest.       |
+| Maximum                  | `MAX_WITH_INTEREST`    | Will display the maximum installment option having interest or not. |
+
+For `PreferredSKUEnum`:
+
+| Name              | Value             | Description                                                                              |
+| ----------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| First Available   | `FIRST_AVAILABLE` | Selects the first available SKU in stock it finds.                                       |
+| Last Available    | `LAST_AVAILABLE`  | Selects the last available SKU in stock it finds.                                        |
+| Cheapest          | `PRICE_ASC`       | Selects the cheapest SKU in stock it finds.                                              |
+| Most Expensive    | `PRICE_DESC`      | Selects the most expensive SKU in stock it finds.                                        |
+| A specific SKU ID | `SPECIFICATION`   | Selects the desired SKU, see how to do it in [Recipes](https://vtex.io/docs/recipes/all) |

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "devDependencies": {
-    "@vtex/prettier-config": "^0.3.1",
+    "@vtex/prettier-config": "^0.3.6",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.4.0",
     "eslint-config-vtex": "^12.7.0",

--- a/react/ProductSummaryList.tsx
+++ b/react/ProductSummaryList.tsx
@@ -7,6 +7,7 @@ import { usePixel } from 'vtex.pixel-manager'
 import { ProductList as ProductListStructuredData } from 'vtex.structured-data'
 
 import ProductSummaryListWithoutQuery from './ProductSummaryListWithoutQuery'
+import { PreferenceType } from './utils/normalize'
 
 const ORDER_BY_OPTIONS = {
   RELEVANCE: {
@@ -102,6 +103,10 @@ interface Props {
    * Name of the list property on Google Analytics events.
    */
   listName?: string
+  /**
+   * Logic to enable which SKU will be the selected item
+   * */
+  preferredSKU?: PreferenceType
   /** Slot of a product summary. */
   ProductSummary: ComponentType<{ product: any; actionOnClick: any }>
   /** Callback on product click. */
@@ -122,6 +127,7 @@ function ProductSummaryList(props: PropsWithChildren<Props>) {
     listName: rawListName,
     ProductSummary,
     actionOnProductClick,
+    preferredSKU,
   } = props
 
   const { push } = usePixel()
@@ -177,6 +183,7 @@ function ProductSummaryList(props: PropsWithChildren<Props>) {
       listName={listName}
       ProductSummary={ProductSummary}
       actionOnProductClick={productClick}
+      preferredSKU={preferredSKU}
     >
       <ProductListStructuredData products={products} />
       {children}

--- a/react/ProductSummaryListWithoutQuery.tsx
+++ b/react/ProductSummaryListWithoutQuery.tsx
@@ -4,7 +4,10 @@ import { ExtensionPoint, useTreePath } from 'vtex.render-runtime'
 import { useListContext, ListContextProvider } from 'vtex.list-context'
 import { ProductListContext } from 'vtex.product-list-context'
 
-import { mapCatalogProductToProductSummary } from './utils/normalize'
+import {
+  mapCatalogProductToProductSummary,
+  PreferenceType,
+} from './utils/normalize'
 import ProductListEventCaller from './components/ProductListEventCaller'
 import type { ProductClickParams } from './ProductSummaryList'
 
@@ -30,6 +33,8 @@ type Props = PropsWithChildren<{
     product: any,
     productClickParams?: ProductClickParams
   ) => void
+  /** Logic to enable which SKU will be the selected item */
+  preferredSKU?: PreferenceType
 }>
 
 function List({
@@ -38,13 +43,17 @@ function List({
   ProductSummary,
   listName,
   actionOnProductClick,
+  preferredSKU,
 }: Props) {
   const { list } = useListContext()
   const { treePath } = useTreePath()
 
   const newListContextValue = useMemo(() => {
     const componentList = products?.map((product, index) => {
-      const normalizedProduct = mapCatalogProductToProductSummary(product)
+      const normalizedProduct = mapCatalogProductToProductSummary(
+        product,
+        preferredSKU
+      )
       const position = list.length + index + 1
 
       const handleOnClick = () => {
@@ -96,10 +105,12 @@ function ProductSummaryListWithoutQuery({
   listName,
   ProductSummary,
   actionOnProductClick,
+  preferredSKU,
 }: Props) {
   return (
     <ProductListProvider listName={listName ?? ''}>
       <List
+        preferredSKU={preferredSKU}
         products={products}
         listName={listName}
         ProductSummary={ProductSummary}

--- a/react/ProductSummaryListWithoutQuery.tsx
+++ b/react/ProductSummaryListWithoutQuery.tsx
@@ -54,6 +54,7 @@ function List({
         product,
         preferredSKU
       )
+
       const position = list.length + index + 1
 
       const handleOnClick = () => {
@@ -90,7 +91,15 @@ function List({
     })
 
     return list.concat(componentList ?? [])
-  }, [products, list, ProductSummary, treePath, listName, actionOnProductClick])
+  }, [
+    products,
+    list,
+    preferredSKU,
+    ProductSummary,
+    treePath,
+    listName,
+    actionOnProductClick,
+  ])
 
   return (
     <ListContextProvider list={newListContextValue}>

--- a/react/__tests__/ProductSummary.test.js
+++ b/react/__tests__/ProductSummary.test.js
@@ -1,8 +1,12 @@
 import ProductSummary from '../ProductSummaryCustom'
 
 describe('<ProductSummary /> component', () => {
-  it(`should parse a product succesfully and get sku as the first with available quantity`, () => {
-    const product = {
+  it(`should parse a catalog product and get an available SKU with the highest price`, () => {
+    const inheritedProps = {
+      preferredSKU: 'PRICE_ASC',
+    }
+
+    const mockProduct = {
       productId: '123456789',
       linkText: 'linkText',
       productName: 'productName',
@@ -15,7 +19,7 @@ describe('<ProductSummary /> component', () => {
               sellerId: '1',
               commertialOffer: {
                 AvailableQuantity: 0,
-                Price: 10,
+                Price: 100,
               },
             },
           ],
@@ -38,7 +42,30 @@ describe('<ProductSummary /> component', () => {
               sellerId: '1',
               commertialOffer: {
                 AvailableQuantity: 3,
-                Price: 15,
+                Price: 50,
+              },
+            },
+          ],
+          images: [
+            {
+              imageUrl: 'image1',
+              imageLabel: null,
+            },
+            {
+              imageUrl: 'image2',
+              imageLabel: null,
+            },
+          ],
+        },
+        {
+          itemId: '3',
+          name: 'item 3',
+          sellers: [
+            {
+              sellerId: '1',
+              commertialOffer: {
+                AvailableQuantity: 1,
+                Price: 500,
               },
             },
           ],
@@ -59,14 +86,114 @@ describe('<ProductSummary /> component', () => {
           name: 'name',
         },
       ],
-      quantity: 1,
+      properties: [],
     }
 
-    const result = ProductSummary.mapCatalogProductToProductSummary(product)
+    const result = ProductSummary.mapCatalogProductToProductSummary(
+      mockProduct,
+      inheritedProps.preferredSKU
+    )
 
     expect(result).toBeDefined()
     expect(result.sku.seller.sellerId).toBe('1')
     expect(result.sku.image).toBeDefined()
+    expect(result.sku.itemId).toBe('3')
+  })
+
+  it(`should parse a catalog product and get a specific SKU by it's properties`, () => {
+    const inheritedProps = {
+      preferredSKU: 'LAST_AVAILABLE',
+    }
+
+    const mockProduct = {
+      productId: '123456789',
+      linkText: 'linkText',
+      productName: 'productName',
+      items: [
+        {
+          itemId: '1',
+          name: 'item 1',
+          sellers: [
+            {
+              sellerId: '1',
+              commertialOffer: {
+                AvailableQuantity: 0,
+                Price: 100,
+              },
+            },
+          ],
+          images: [
+            {
+              imageUrl: 'image1',
+              imageLabel: null,
+            },
+            {
+              imageUrl: 'image2',
+              imageLabel: null,
+            },
+          ],
+        },
+        {
+          itemId: '2',
+          name: 'item 2',
+          sellers: [
+            {
+              sellerId: '1',
+              commertialOffer: {
+                AvailableQuantity: 3,
+                Price: 50,
+              },
+            },
+          ],
+          images: [
+            {
+              imageUrl: 'image1',
+              imageLabel: null,
+            },
+            {
+              imageUrl: 'image2',
+              imageLabel: null,
+            },
+          ],
+        },
+        {
+          itemId: '3',
+          name: 'item 3',
+          sellers: [
+            {
+              sellerId: '1',
+              commertialOffer: {
+                AvailableQuantity: 1,
+                Price: 500,
+              },
+            },
+          ],
+          images: [
+            {
+              imageUrl: 'image1',
+              imageLabel: null,
+            },
+            {
+              imageUrl: 'image2',
+              imageLabel: null,
+            },
+          ],
+        },
+      ],
+      productClusters: [
+        {
+          name: 'name',
+        },
+      ],
+      properties: [{ name: 'DefaultSKUSelected', values: ['2'] }],
+    }
+
+    const result = ProductSummary.mapCatalogProductToProductSummary(
+      mockProduct,
+      inheritedProps.preferredSKU
+    )
+
+    expect(result).toBeDefined()
     expect(result.sku.itemId).toBe('2')
   })
 

--- a/react/__tests__/ProductSummary.test.js
+++ b/react/__tests__/ProductSummary.test.js
@@ -97,7 +97,7 @@ describe('<ProductSummary /> component', () => {
     expect(result).toBeDefined()
     expect(result.sku.seller.sellerId).toBe('1')
     expect(result.sku.image).toBeDefined()
-    expect(result.sku.itemId).toBe('3')
+    expect(result.sku.itemId).toBe('2')
   })
 
   it(`should parse a catalog product and get a specific SKU by it's properties`, () => {

--- a/react/__tests__/ProductSummaryImage.test.js
+++ b/react/__tests__/ProductSummaryImage.test.js
@@ -5,6 +5,10 @@ import ProductImage from '../ProductSummaryImage'
 import ProductSummary from '../ProductSummaryCustom'
 
 describe('<ProductImage /> component', () => {
+  const inheritedProps = {
+    preferredSKU: 'FIRST_AVAILABLE',
+  }
+
   it('should render one img element', () => {
     const rawProduct = {
       productId: '123456789',
@@ -40,7 +44,10 @@ describe('<ProductImage /> component', () => {
       quantity: 1,
     }
 
-    const product = ProductSummary.mapCatalogProductToProductSummary(rawProduct)
+    const product = ProductSummary.mapCatalogProductToProductSummary(
+      rawProduct,
+      inheritedProps.preferredSKU
+    )
 
     const { container } = render(
       <ProductSummary product={product}>
@@ -85,7 +92,10 @@ describe('<ProductImage /> component', () => {
       quantity: 1,
     }
 
-    const product = ProductSummary.mapCatalogProductToProductSummary(rawProduct)
+    const product = ProductSummary.mapCatalogProductToProductSummary(
+      rawProduct,
+      inheritedProps.preferredSKU
+    )
 
     const { container } = render(
       <ProductSummary product={product}>
@@ -133,7 +143,10 @@ describe('<ProductImage /> component', () => {
 
     const placeholder = 'placeholder-image-url'
 
-    const product = ProductSummary.mapCatalogProductToProductSummary(rawProduct)
+    const product = ProductSummary.mapCatalogProductToProductSummary(
+      rawProduct,
+      inheritedProps.preferredSKU
+    )
 
     const { container } = render(
       <ProductSummary product={product}>

--- a/react/package.json
+++ b/react/package.json
@@ -30,18 +30,18 @@
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.on-view": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.8.0/public/@types/vtex.pixel-manager",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
     "vtex.product-list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.4.0/public/@types/vtex.product-list-context",
     "vtex.product-specification-badges": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.3.0/public/@types/vtex.product-specification-badges",
-    "vtex.product-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary@2.73.1/public/@types/vtex.product-summary",
+    "vtex.product-summary": "https://specification--motoroladevelopment.myvtex.com/_v/private/typings/linked/v1/vtex.product-summary@2.74.1+build1628605519/public/@types/vtex.product-summary",
     "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.8.1/public/@types/vtex.product-summary-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.129.0/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.2/public/@types/vtex.responsive-values",
     "vtex.search-page-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-page-context@0.2.0/public/@types/vtex.search-page-context",
-    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.80.0/public/@types/vtex.store-resources",
-    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.6.0/public/@types/vtex.structured-data",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.143.0/public/@types/vtex.styleguide"
+    "vtex.store-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.149.1/public/@types/vtex.store-components",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.84.0/public/@types/vtex.store-resources",
+    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.0/public/@types/vtex.structured-data",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide"
   },
   "vtexScriptsOverride": {
     "srcPath": "."

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -89,6 +89,7 @@ function getPriceBySeller(seller: { commertialOffer: { Price: number } }) {
 function getPriceByCondition(item: { sellers: any }, condition: ConditionRule) {
   // First, if there's only 1 seller, avoid filtering
   const { sellers } = item
+
   if (sellers.length === 1) return sellers[0].commertialOffer.Price
 
   const availableSellers = sellers.filter(
@@ -98,11 +99,13 @@ function getPriceByCondition(item: { sellers: any }, condition: ConditionRule) {
   )
 
   let itemPrice
+
   if (condition === 'expensive') {
     itemPrice = Math.max(...availableSellers.map(getPriceBySeller))
   } else {
     itemPrice = Math.min(...availableSellers.map(getPriceBySeller))
   }
+
   return itemPrice
 }
 
@@ -115,6 +118,7 @@ function getPriceByCondition(item: { sellers: any }, condition: ConditionRule) {
 function getBestSKUPrice(items: any[], condition: ConditionRule) {
   // First, if none or only 1 sku is available, avoid reducing
   const filteredItems = items.filter(getOnlyAvailable)
+
   if (filteredItems.length === 0) return items[0]
   if (filteredItems.length === 1) return filteredItems[0]
 
@@ -124,12 +128,12 @@ function getBestSKUPrice(items: any[], condition: ConditionRule) {
         getPriceByCondition(acc, condition)
         ? curr
         : acc
-    } else {
-      return getPriceByCondition(curr, condition) <
-        getPriceByCondition(acc, condition)
-        ? curr
-        : acc
     }
+
+    return getPriceByCondition(curr, condition) <
+      getPriceByCondition(acc, condition)
+      ? curr
+      : acc
   })
 }
 
@@ -141,7 +145,7 @@ function getBestSKUPrice(items: any[], condition: ConditionRule) {
  * @see {@link https://vtex.io/docs/recipes/all} recipe on how to implement this
  * */
 function getSpecificSKU(items: any[], specifications: any[]) {
-  let defaultSKUspec =
+  const defaultSKUspec =
     specifications.find(
       (spec: { name: string }) => spec.name === 'DefaultSKUSelected'
     ) ?? null
@@ -154,9 +158,9 @@ function getSpecificSKU(items: any[], specifications: any[]) {
 
   if (specificSKU.length) {
     return specificSKU[0]
-  } else {
-    return items[0]
   }
+
+  return items[0]
 }
 
 /**
@@ -202,12 +206,16 @@ function findPreferredSKU(
     default:
     case 'FIRST_AVAILABLE':
       return items.find(findAvailableProduct) || items[0]
+
     case 'LAST_AVAILABLE':
       return items.reverse().find(findAvailableProduct) || items.reverse()[0]
+
     case 'PRICE_ASC':
       return getBestSKUPrice(items, 'cheapest')
+
     case 'PRICE_DESC':
       return getBestSKUPrice(items, 'expensive')
+
     case 'SPECIFICATION':
       return getSpecificSKU(items, properties)
   }

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -188,7 +188,7 @@ function findDefaultSKU(
   )
 
   if (specificSKU) {
-    return specificSKU[0]
+    return specificSKU
   }
 
   return findPreferredSKU(items, preferenceFallback)

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -169,7 +169,7 @@ function findAnyAvailable({ sellers }: ProductTypes.Item) {
  * @description
  * Attempts to retrieve the specific SKU using a custom Product (field)
  * in the Catalog. The specification has the value of the SKU ID
- * that will be looking for. If not found by any reason, we default
+ * that will be looking for. If not found for any reason, we default
  * to finding the preferred SKU
  * @param items an array of SKUs
  * @param defaultSKUspec the ID used to find the SKU
@@ -231,7 +231,7 @@ const resizeImage = (url: string, imageSize: string | number) =>
 
 /**
  * @description
- * This method is responsible of constructing the product type for the product-context.
+ * This method is responsible for constructing the product type for the product-context.
  * The property `product.sku` is built by these specifications
  * */
 export function mapCatalogProductToProductSummary(

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -12,7 +12,6 @@ export type PreferenceType =
   | 'LAST_AVAILABLE'
   | 'PRICE_ASC'
   | 'PRICE_DESC'
-  | 'SPECIFICATION'
 
 type PriceConditionRule = 'lowest' | 'highest'
 

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -118,11 +118,10 @@ function getPriceByCondition(item: { sellers: any }, condition: ConditionRule) {
 function getBestSKUPrice(items: any[], condition: ConditionRule) {
   // First, if none or only 1 sku is available, avoid reducing
   const filteredItems = items.filter(getOnlyAvailable)
-
   if (filteredItems.length === 0) return items[0]
   if (filteredItems.length === 1) return filteredItems[0]
 
-  return items.reduce((acc: any, curr: any) => {
+  return filteredItems.reduce((acc: any, curr: any) => {
     if (condition === 'expensive') {
       return getPriceByCondition(curr, condition) >
         getPriceByCondition(acc, condition)

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import type { ProductTypes } from 'vtex.product-context'
 
 import { getDefaultSeller } from '../modules/seller'
@@ -169,7 +168,7 @@ function findAnyAvailable({ sellers }: ProductTypes.Item) {
  * @param preferenceFallback the logic for finding an SKU if the ID fails
  * @see {@link https://vtex.io/docs/recipes/all} recipe on how to implement this
  * */
-/* function findDefaultSKU(
+function findDefaultSKU(
   items: ProductTypes.Item[],
   defaultSKUspec: string[],
   preferenceFallback: PreferenceType
@@ -183,7 +182,7 @@ function findAnyAvailable({ sellers }: ProductTypes.Item) {
   }
 
   return findPreferredSKU(items, preferenceFallback)
-} */
+}
 
 /**
  * @description
@@ -241,17 +240,13 @@ export function mapCatalogProductToProductSummary(
       (spec: { name: string }) => spec.name === 'DefaultSKUSelected'
     ) ?? null
 
-  console.log(preferredSKU)
-
   // The SKU will be responsible of setting the `selectedItem` in the product context.
   let sku
 
   if (items.length === 1) {
     sku = items[0]
   } else if (defaultSKUspec) {
-    sku = findPreferredSKU(items, preferredSKU)
-
-    // sku = findDefaultSKU(items, defaultSKUspec.values, preferredSKU)
+    sku = findDefaultSKU(items, defaultSKUspec.values, preferredSKU)
   } else {
     sku = findPreferredSKU(items, preferredSKU)
   }

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -211,7 +211,7 @@ function findPreferredSKU(
     case 'LAST_AVAILABLE':
       return (
         [...items].reverse().find(getAvailableProduct) ??
-        [...items].reverse()[0]
+        items[items.length - 1]
       )
 
     case 'PRICE_ASC':

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -97,7 +97,9 @@ function getBestPrice(item: ProductTypes.Item, condition: PriceConditionRule) {
   // If there's only 1 seller, avoid filtering
   const { sellers } = item
 
-  if (sellers.length === 1) return sellers[0].commertialOffer.Price
+  if (sellers.length === 1) {
+    return sellers[0].commertialOffer.Price
+  }
 
   const availableSellers = sellers.filter(isAvailable)
   const allPrices = availableSellers.map(getPriceFromSeller)

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -183,11 +183,11 @@ function findDefaultSKU(
   defaultSKUspec: string[],
   preferenceFallback: PreferenceType
 ) {
-  const specificSKU = items.filter(
+  const specificSKU = items.find(
     ({ itemId }) => String(itemId) === String(defaultSKUspec)
   )
 
-  if (specificSKU.length) {
+  if (specificSKU) {
     return specificSKU[0]
   }
 

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -101,13 +101,14 @@ function getBestPrice(item: ProductTypes.Item, condition: PriceConditionRule) {
   if (sellers.length === 1) return sellers[0].commertialOffer.Price
 
   const availableSellers = sellers.filter(isAvailable)
+  const allPrices = availableSellers.map(getPriceFromSeller)
 
   let itemPrice
 
   if (condition === 'highest') {
-    itemPrice = Math.max(...availableSellers.map(getPriceFromSeller))
+    itemPrice = allPrices.reduce((max, price) => (price > max ? price : max))
   } else {
-    itemPrice = Math.min(...availableSellers.map(getPriceFromSeller))
+    itemPrice = allPrices.reduce((min, price) => (price < min ? price : min))
   }
 
   return itemPrice
@@ -133,10 +134,18 @@ function findSKUByPrice(
   let itemToReturn
 
   if (condition === 'highest') {
-    itemToReturn = bestPrices.indexOf(Math.max(...bestPrices))
+    itemToReturn = bestPrices.reduce(
+      (maxIndex, currentPrice, currentIndex) =>
+        currentPrice > bestPrices[maxIndex] ? currentIndex : maxIndex,
+      0
+    )
+  } else {
+    itemToReturn = bestPrices.reduce(
+      (minIndex, currentPrice, currentIndex) =>
+        currentPrice < bestPrices[minIndex] ? currentIndex : minIndex,
+      0
+    )
   }
-
-  itemToReturn = bestPrices.indexOf(Math.min(...bestPrices))
 
   return availableItems[itemToReturn]
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5018,9 +5018,9 @@ verror@1.10.0:
   version "1.8.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.8.0/public/@types/vtex.pixel-manager#3ccfcb1927614984a5f7a3e5650c8c8d2bd3c0f4"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context":
-  version "0.9.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.9/public/@types/vtex.product-context#d9619a3365c1b04c1110c4beb11a53eae39aac75"
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
 
 "vtex.product-list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.4.0/public/@types/vtex.product-list-context":
   version "0.4.0"
@@ -5034,13 +5034,13 @@ verror@1.10.0:
   version "0.8.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.8.1/public/@types/vtex.product-summary-context#df39f9e59c3f09246d38b32c90a0f802864cce72"
 
-"vtex.product-summary@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary@2.73.1/public/@types/vtex.product-summary":
-  version "2.73.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary@2.73.1/public/@types/vtex.product-summary#3850be70d0c2603e10ef45a35982d9c83e537e27"
+"vtex.product-summary@https://specification--motoroladevelopment.myvtex.com/_v/private/typings/linked/v1/vtex.product-summary@2.74.1+build1628605519/public/@types/vtex.product-summary":
+  version "2.74.1"
+  resolved "https://specification--motoroladevelopment.myvtex.com/_v/private/typings/linked/v1/vtex.product-summary@2.74.1+build1628605519/public/@types/vtex.product-summary#ec208382c77a57bc3fe48fa01cda790a4039a364"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.129.0/public/@types/vtex.render-runtime":
-  version "8.129.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.129.0/public/@types/vtex.render-runtime#76dd55634b06288d8209d5b85ca26b6f6692a889"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime":
+  version "8.131.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime#dcc88828e3d65ecb4e7538a3623a4b1ddd77e034"
 
 "vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.2/public/@types/vtex.responsive-values":
   version "0.4.2"
@@ -5050,21 +5050,21 @@ verror@1.10.0:
   version "0.2.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-page-context@0.2.0/public/@types/vtex.search-page-context#1b37f20648d8e4ff062ae9fffb0aa2718f172af7"
 
-"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components":
-  version "3.144.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.144.0/public/@types/vtex.store-components#7731a0fb7cec831b93b5037c6f694205eb34a247"
+"vtex.store-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.149.1/public/@types/vtex.store-components":
+  version "3.149.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-components@3.149.1/public/@types/vtex.store-components#451a14e436af9611c9f4f9d682a46c56321fc4b2"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.80.0/public/@types/vtex.store-resources":
-  version "0.80.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.80.0/public/@types/vtex.store-resources#6a8fcee940127f4e7adae84b26857a134328f236"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.84.0/public/@types/vtex.store-resources":
+  version "0.84.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.84.0/public/@types/vtex.store-resources#51431e5ae7ea64e90e345407e4720b152e81a816"
 
-"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.6.0/public/@types/vtex.structured-data":
-  version "0.6.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.6.0/public/@types/vtex.structured-data#39b3032db55a52544655a7fca8fcb792a0baae78"
+"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.0/public/@types/vtex.structured-data":
+  version "0.7.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.0/public/@types/vtex.structured-data#d5bf90738149074c2239243b58d8fcfa0bab2cf4"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.143.0/public/@types/vtex.styleguide":
-  version "9.143.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.143.0/public/@types/vtex.styleguide#a25555601abee353ed3e859ffb57e98c9e07e911"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide":
+  version "9.145.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide#41dfb32af8756eb5528dbd452e47003a8f67fe8c"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,10 +176,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@vtex/prettier-config@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@vtex/prettier-config/-/prettier-config-0.3.1.tgz#c376999e826827aa11f4b0e08af9cf59ae9ee476"
-  integrity sha512-B2tvaxrWXAzF2iSaRpQaw88kxq1lGC7/DSOBuGOn9225wNrF5g6D6NNky4/TZomv0NJTgO8tIT59ftbTHgMxXg==
+"@vtex/prettier-config@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@vtex/prettier-config/-/prettier-config-0.3.6.tgz#31762608d9a59b815b6d4e963e439b12f1a12279"
+  integrity sha512-nXE3BcMODomFK3EowfK+Hdj2qQRqB8JcdRv8yTREXnN9xq8DYKmH/dWB+RY/Hn3KozFLbygpZRbqYsiA6HDINQ==
 
 acorn-jsx@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
#### What problem is this solving?

There was no way of specifying which SKU should be the initial selection in product summaries (Both sliders and galleries).
We are now letting the client specify a logic to then use it for the product-context, which in turn will provide the selected item property to it's childrens.

#### How to test it?

[CHEAPEST](https://cheapest--motoroladevelopment.myvtex.com/)
(You will see the cheapest products selected)

[SPECIFICATION](https://specification--motoroladevelopment.myvtex.com/Smartphones/Moto-G-Family?page=1)
(Look for MOTO G7 PLUS, you will see that the SKU No. 35 is selected, thanks to it's product property called `DefaultSKU`)

#### Screenshots or example usage:
For i.e:
By passing "SPECIFICATION" the SKU No. 35 was automatically selected in the Gallery

![item](https://user-images.githubusercontent.com/50715158/128880853-a9e5dd43-9f25-41de-95cc-f74b153a6299.png)

#### Describe alternatives you've considered, if any.

We know that the Admin SKU Position exists, but as of today, this is not working (Confirmed by Catalog team)

#### Related to / Depends on

[Search result PR](https://github.com/vtex-apps/search-result/pull/536)

#### How does this PR make you feel? 

![](https://media.giphy.com/media/5UB7rGI71YHBsuRQdi/giphy.gif)
