### PR TITLE
Add asyncOnly1P to priceBehavior prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `asyncOnly1P` to `priceBehavior`.
+
 ## [2.74.1] - 2021-08-09
 
 ### Changed

--- a/docs/ProductSummaryShelf.md
+++ b/docs/ProductSummaryShelf.md
@@ -45,7 +45,7 @@ Product Summary Shelf is the main block exported by the Product Summary app. Thr
 
 | Prop name        | Type          | Description                | Default value  |
 | :--------------: | :---------: | :--------------------------: | :------------: |
-| `priceBehavior` | `enum` | Whether the component should fetch the most up-to-date price for all sellers (`async`), only for the first party seller (`asyncOnly1P`) or will not fetch the most up-to-date price (`default`). Remember to also set the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s`simulationBehavior` prop to `skip` and use the Product Price's [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price data is being fetched. | `default` |
+| `priceBehavior` | `enum` | Whether the component should fetch the most up-to-date price (`async`) or not (`default`). Remember to also set the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s`simulationBehavior` prop to `skip` and use the Product Price's [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price data is being fetched. | `default` |
 | `trackListName` | `boolean` | Whether the component should send the list name to the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated from. | `true` |
 
 ## Customization

--- a/docs/ProductSummaryShelf.md
+++ b/docs/ProductSummaryShelf.md
@@ -45,7 +45,7 @@ Product Summary Shelf is the main block exported by the Product Summary app. Thr
 
 | Prop name        | Type          | Description                | Default value  |
 | :--------------: | :---------: | :--------------------------: | :------------: |
-| `priceBehavior` | `enum` | Whether the component should fetch the most up-to-date price (`async`) or not (`default`). Remember to also set the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s`simulationBehavior` prop to `skip` and use the Product Price's [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price data is being fetched. | `default` |
+| `priceBehavior` | `enum` | Whether the component should fetch the most up-to-date price for all sellers (`async`), only for the first party seller (`asyncOnly1P`) or will not fetch the most up-to-date price (`default`). Remember to also set the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s`simulationBehavior` prop to `skip` and use the Product Price's [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price data is being fetched. | `default` |
 | `trackListName` | `boolean` | Whether the component should send the list name to the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated from. | `true` |
 
 ## Customization

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.74.1",
+  "version": "2.75.0-hkignore.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.75.0-hkignore.0",
+  "version": "2.75.0-hkignore.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -185,10 +185,10 @@ interface Props {
   actionOnClick?: () => void
   href?: string
   /**
-   * Whether the client will request the simulation API ("async") or not "default"
+   * Whether the client will request the simulation API for all sellers ("async"), only for the 1P seller ("asyncOnly1P") or if will not request the API ("default")
    * @default "default"
    */
-  priceBehavior?: 'async' | 'default'
+  priceBehavior?: 'async' | 'asyncOnly1P' | 'default'
   /**
    * Name of the list the Product Summary is in. Should be set by a Shelf or the Search Result gallery.
    */
@@ -221,7 +221,9 @@ function ProductSummaryWrapper({
     <ProductSummaryProvider
       product={product}
       listName={trackListName ? listName : undefined}
-      isPriceLoading={priceBehavior === 'async'}
+      isPriceLoading={
+        priceBehavior === 'async' || priceBehavior === 'asyncOnly1P'
+      }
     >
       <ProductSummaryCustom
         product={product}

--- a/react/components/ProductPriceSimulationWrapper.tsx
+++ b/react/components/ProductPriceSimulationWrapper.tsx
@@ -9,7 +9,7 @@ import useSetProduct from '../hooks/useSetProduct'
 interface Props {
   product: ProductSummaryTypes.Product
   inView: boolean
-  priceBehavior: 'async' | 'default'
+  priceBehavior: 'async' | 'asyncOnly1P' | 'default'
 }
 
 function ProductPriceSimulationWrapper({

--- a/react/hooks/useSimulation.ts
+++ b/react/hooks/useSimulation.ts
@@ -103,7 +103,7 @@ function useSimulation({
             (seller) => seller.sellerId === '1'
           )
 
-          const { sellers } = item
+          const sellers = Array.from(item.sellers)
 
           sellers[seller1PIndex] = simulationItem.sellers[0]
           const sellerDefault = getDefaultSeller(sellers)

--- a/react/hooks/useSimulation.ts
+++ b/react/hooks/useSimulation.ts
@@ -45,7 +45,7 @@ type Params = {
   inView: boolean
   onComplete: (product: ProductSummaryTypes.Product) => void
   onError: () => void
-  priceBehavior: 'async' | 'default'
+  priceBehavior: 'async' | 'asyncOnly1P' | 'default'
 }
 
 function useSimulation({
@@ -57,22 +57,25 @@ function useSimulation({
 }: Params) {
   const items = product.items || []
 
-  const simulationItemsInput = useMemo(
-    () =>
-      items.map((item) => ({
+  const simulationItemsInput = useMemo(() => {
+    if (priceBehavior === 'async') {
+      return items.map((item) => ({
         itemId: item.itemId,
-        sellers: item.sellers.map((seller) => ({
-          sellerId: seller.sellerId,
-        })),
-      })),
-    [items]
-  )
+        sellers: item.sellers.map((seller) => ({ sellerId: seller.sellerId })),
+      }))
+    }
+
+    return items.map((item) => ({
+      itemId: item.itemId,
+      sellers: [{ sellerId: '1' }],
+    }))
+  }, [items, priceBehavior])
 
   useQuery(QueryItemsWithSimulation, {
     variables: {
       items: simulationItemsInput,
     },
-    skip: priceBehavior !== 'async' || !inView,
+    skip: priceBehavior === 'default' || !inView,
     ssr: false,
     onError,
     onCompleted: (response) => {
@@ -87,13 +90,41 @@ function useSimulation({
       mergedProduct.items.forEach((item, itemIndex) => {
         const simulationItem = simulationItems[itemIndex]
 
-        const sellerDefault = getDefaultSeller(simulationItem.sellers)
+        if (priceBehavior === 'async') {
+          const sellerDefault = getDefaultSeller(simulationItem.sellers)
 
-        item.sellers = item.sellers.map((seller, simulationIndex) => {
-          const sellerSimulation = simulationItem.sellers[simulationIndex]
+          item.sellers = item.sellers.map((seller, simulationIndex) => {
+            const sellerSimulation = simulationItem.sellers[simulationIndex]
 
-          return mergeSellers(seller, sellerSimulation, sellerDefault)
-        })
+            return mergeSellers(seller, sellerSimulation, sellerDefault)
+          })
+        } else {
+          const seller1PIndex = item.sellers.findIndex(
+            (seller) => seller.sellerId === '1'
+          )
+
+          const { sellers } = item
+
+          sellers[seller1PIndex] = simulationItem.sellers[0]
+          const sellerDefault = getDefaultSeller(sellers)
+
+          item.sellers = item.sellers.map((seller) => {
+            if (seller.sellerId !== '1') {
+              return !sellerDefault
+                ? seller
+                : {
+                    ...seller,
+                    sellerDefault: seller.sellerId === sellerDefault,
+                  }
+            }
+
+            return mergeSellers(
+              seller,
+              simulationItem.sellers[0],
+              sellerDefault
+            )
+          })
+        }
       })
 
       mergedProduct.sku = mergedProduct.items.find(
@@ -101,9 +132,9 @@ function useSimulation({
       ) as ProductSummaryTypes.SingleSKU
 
       if (mergedProduct.sku.sellers.length > 0) {
-        mergedProduct.sku.seller = mergedProduct.sku.sellers.find(
+        mergedProduct.sku.seller = (mergedProduct.sku.sellers.find(
           (seller) => seller.sellerDefault
-        ) as ProductSummaryTypes.Seller
+        ) ?? mergedProduct.sku.sellers[0]) as ProductSummaryTypes.Seller
       } else {
         mergedProduct.sku.seller = {
           // @ts-expect-error We are not providing the full type


### PR DESCRIPTION
#### What problem is this solving?

get the most updated price by simulation only for seller 1, avoiding making many calls to the API at the same time. 
with this, all other sellers will use the price and availability that are returned by the search query, and only seller 1 will have the price being retrieved asynchronously.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://thalyta--carrefourbr.myvtex.com)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
