### PR TITLE
added lazyload prop to images

### DIFF
--- a/react/productSummary.css
+++ b/react/productSummary.css
@@ -90,6 +90,15 @@
 .hoverEffect:hover .mainImageHovered {
   opacity: 0;
 }
+.hoverEffect:hover > span.containerSpinner {
+  display: block;
+}
+span.containerSpinner{
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: none;
+}
 
 .hoverImage {
 }


### PR DESCRIPTION
#### What problem is this solving?
 Saving a lot of data of being downloaded without needs

<!--- What is the motivation and context for this change? -->
My client would like to add the hover functionality on shelves of category and collection, however the page is load with 20 shelves, and every shelf has a picture, when hover is acitved, the number of images go from 20 to 40, this decreases our performance score. With this feature, the page will only load 20 pictures and whenever the user hovers through a shelf, then it will download the next image and show it

#### How to test it?
Just browse through the shelves with the network pannel opened and you will see
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://izaac--dzarm.myvtex.com/novidades)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![]https://media.giphy.com/media/YMMMW0E95cW8URC1No/giphy.gif)
