### PR TITLE
fix getDefaultSeller and onCompleted function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use `spotPrice` to get the default seller
+- Bug where the `onCompleted` function in the `useSimulation` hook was only being executed once.
+
 ## [2.75.0] - 2021-08-23
 
 ### Added

--- a/react/components/ProductPriceSimulationWrapper.tsx
+++ b/react/components/ProductPriceSimulationWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import type { PropsWithChildren } from 'react'
 import { ProductSummaryContext } from 'vtex.product-summary-context'
 import type { ProductSummaryTypes } from 'vtex.product-summary-context'
@@ -21,17 +21,8 @@ function ProductPriceSimulationWrapper({
   const productSummaryDispatch = ProductSummaryContext.useProductSummaryDispatch()
   const setProduct = useSetProduct()
 
-  useSimulation({
-    product,
-    inView,
-    priceBehavior,
-    onError: () => {
-      productSummaryDispatch({
-        type: 'SET_PRICE_LOADING',
-        args: { isPriceLoading: false },
-      })
-    },
-    onComplete: (simulatedProduct) => {
+  const onComplete = useCallback(
+    (simulatedProduct) => {
       setProduct(simulatedProduct)
 
       productSummaryDispatch({
@@ -39,6 +30,22 @@ function ProductPriceSimulationWrapper({
         args: { isPriceLoading: false },
       })
     },
+    [setProduct, productSummaryDispatch]
+  )
+
+  const onError = useCallback(() => {
+    productSummaryDispatch({
+      type: 'SET_PRICE_LOADING',
+      args: { isPriceLoading: false },
+    })
+  }, [productSummaryDispatch])
+
+  useSimulation({
+    product,
+    inView,
+    priceBehavior,
+    onError,
+    onComplete,
   })
 
   return <>{children}</>

--- a/react/hooks/useSetProduct.ts
+++ b/react/hooks/useSetProduct.ts
@@ -2,6 +2,7 @@ import { useProduct, useProductDispatch } from 'vtex.product-context'
 import type { ProductTypes } from 'vtex.product-context'
 import { ProductSummaryContext } from 'vtex.product-summary-context'
 import type { ProductSummaryTypes } from 'vtex.product-summary-context'
+import { useCallback } from 'react'
 
 const { useProductSummaryDispatch } = ProductSummaryContext
 
@@ -10,26 +11,29 @@ function useSetProduct() {
   const productSummaryDispatch = useProductSummaryDispatch()
   const productDispatch = useProductDispatch()
 
-  return (product: ProductSummaryTypes.Product) => {
-    const newSelectedItem =
-      currentSelectedItem &&
-      product.items.find((item) => item.itemId === currentSelectedItem.itemId)
+  return useCallback(
+    (product: ProductSummaryTypes.Product) => {
+      const newSelectedItem =
+        currentSelectedItem &&
+        product.items.find((item) => item.itemId === currentSelectedItem.itemId)
 
-    productSummaryDispatch({
-      type: 'SET_PRODUCT',
-      args: { product },
-    })
+      productSummaryDispatch({
+        type: 'SET_PRODUCT',
+        args: { product },
+      })
 
-    productDispatch?.({
-      type: 'SET_PRODUCT',
-      args: { product: (product as unknown) as ProductTypes.Product },
-    })
+      productDispatch?.({
+        type: 'SET_PRODUCT',
+        args: { product: (product as unknown) as ProductTypes.Product },
+      })
 
-    productDispatch?.({
-      type: 'SET_SELECTED_ITEM',
-      args: { item: (newSelectedItem as unknown) as ProductTypes.Item },
-    })
-  }
+      productDispatch?.({
+        type: 'SET_SELECTED_ITEM',
+        args: { item: (newSelectedItem as unknown) as ProductTypes.Item },
+      })
+    },
+    [currentSelectedItem, productSummaryDispatch, productDispatch]
+  )
 }
 
 export default useSetProduct

--- a/react/hooks/useSimulation.ts
+++ b/react/hooks/useSimulation.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import type { ProductSummaryTypes } from 'vtex.product-summary-context'
 import { QueryItemsWithSimulation } from 'vtex.store-resources'
@@ -36,7 +36,7 @@ const getDefaultSeller = (sellers: ProductSummaryTypes.Seller[]) => {
   )
 
   return sellersWithStock
-    ?.sort((a, b) => a.commertialOffer.Price - b.commertialOffer.Price)
+    ?.sort((a, b) => a.commertialOffer.spotPrice - b.commertialOffer.spotPrice)
     .map((seller) => seller.sellerId)[0]
 }
 
@@ -55,6 +55,10 @@ function useSimulation({
   onError,
   priceBehavior,
 }: Params) {
+  const [simulatedProduct, setSimulatedProduct] = useState<
+    ProductSummaryTypes.Product
+  >()
+
   const items = product.items || []
 
   const simulationItemsInput = useMemo(() => {
@@ -144,9 +148,15 @@ function useSimulation({
 
       mergedProduct.sku.image = product.sku.image
 
-      onComplete(mergedProduct)
+      setSimulatedProduct(mergedProduct)
     },
   })
+
+  useEffect(() => {
+    if (simulatedProduct) {
+      onComplete(simulatedProduct)
+    }
+  }, [simulatedProduct, onComplete])
 }
 
 export default useSimulation


### PR DESCRIPTION
#### What problem is this solving?

1. The `getDefaultSeller` was using the `Price` to get the default seller instead of the `spotPrice`.
2. Due to [an Apollo behavior](https://github.com/apollographql/react-apollo/issues/3709) , the `onCompleted` function in the `useQuery` is execute only once. This was causing an issue with the price when the product is rerendered. Check the video below.

https://user-images.githubusercontent.com/40380674/132251932-a9ca7de2-0de7-4b97-9207-26333dfe21a5.mov

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--carrefourbr.myvtex.com/busca/notebook?order=)

#### Related to / Depends on

https://github.com/vtex-apps/product-summary-context/pull/21
