### PR TITLE
Add version param to images to permit caching it on CDN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Version param to images to permit caching it on CDN.
+
 ## [2.77.0] - 2021-09-24
 
 ### Added

--- a/react/utils/normalize.ts
+++ b/react/utils/normalize.ts
@@ -32,16 +32,27 @@ const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
 
 const httpRegex = new RegExp(/http:\/\//)
 
+function getParamFromUrl(url: string, name: string) {
+  return (url.split(`${name}=`)[1] || '').split('&')[0]
+}
+
 function toHttps(url: string) {
   return url.replace(httpRegex, 'https://')
 }
 
-function cleanImageUrl(imageUrl: string) {
-  const result = baseUrlRegex.exec(imageUrl)
 
-  if (!result || result.length === 0) return
+export function cleanImageUrl(imageUrl: string) {
+  const cleanUrlResult = baseUrlRegex.exec(imageUrl)
+  const vParam = getParamFromUrl(imageUrl, 'v')
 
-  return result[0]
+  if (cleanUrlResult && cleanUrlResult.length > 0) {
+    return {
+      cleanUrl: cleanUrlResult[0],
+      vParam,
+    }
+  }
+
+  return { cleanUrl: imageUrl }
 }
 
 function replaceLegacyFileManagerUrl(
@@ -54,7 +65,11 @@ function replaceLegacyFileManagerUrl(
 
   if (!isLegacyUrl) return imageUrl
 
-  return `${cleanImageUrl(imageUrl)}-${width}-${height}`
+  const { vParam, cleanUrl } = cleanImageUrl(imageUrl)
+
+  return vParam
+    ? `${cleanUrl}-${width}-${height}?v=${vParam}`
+    : `${cleanUrl}-${width}-${height}`
 }
 
 export function changeImageUrlSize(


### PR DESCRIPTION
#### What problem is this solving?

The problem is explained in this [thread](https://vtex.slack.com/archives/C01PRGM0WG1/p1623092872046100). 

TL;DR: In the @gaoneto words: "Basically we want to add a change that we can cache assets “forever” on the CDN. If we keep things like this (https://dzarm.vtexassets.com/arquivos/pinterest-footer-icon.jpg), for instance, we will not be able to cache indefinitely. If we use as the way Portal does (https://rihappy.vteximg.com.br/arquivos/ids/1407630/banner-full-rihappy-desk-dia-quanto-mais-brincadeira-melhor.png?v=637581831630730000, the ?v parameter changes whenever the asset changes) we are able to cache indefinitely on the CDN."

#### How to test it?

You can test it in the:
- Home page(shelf)
- PLP
- PDP

[Workspace](https://vitorflg--dzarm.myvtex.com/)

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

X