### PR TITLE
added new prop "target" to ProductSummaryCustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 ### Added
-- product card can open card link in a new browser tab.
+- `target` prop to ProductSummaryCustom component.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Added
+- product card can open card link in a new browser tab.
+
 ## [Unreleased]
 
 ## [2.77.1] - 2021-10-08

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -47,8 +47,6 @@ function ProductSummaryCustom({
     query,
     inView,
   } = useProductSummary()
-  console.log("TARGET ",target)
-  console.log("Href ",href)
   const dispatch = useProductSummaryDispatch()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -37,6 +37,7 @@ function ProductSummaryCustom({
   priceBehavior = 'default',
   position,
   classes,
+  target,
 }: PropsWithChildren<Props>) {
   const {
     isLoading,
@@ -46,7 +47,8 @@ function ProductSummaryCustom({
     query,
     inView,
   } = useProductSummary()
-
+  console.log("TARGET ",target)
+  console.log("Href ",href)
   const dispatch = useProductSummaryDispatch()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 
@@ -169,7 +171,7 @@ function ProductSummaryCustom({
             style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
             ref={inViewRef}
           >
-            <Link className={linkClasses} {...linkProps}>
+            <Link className={linkClasses} {...linkProps} target={target}>
               <article className={summaryClasses}>{children}</article>
             </Link>
           </section>
@@ -204,6 +206,7 @@ interface Props {
    */
   position?: number
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  target?: string
 }
 
 function ProductSummaryWrapper({
@@ -216,6 +219,7 @@ function ProductSummaryWrapper({
   position,
   classes,
   children,
+  target,
 }: PropsWithChildren<Props>) {
   return (
     <ProductSummaryProvider
@@ -228,6 +232,7 @@ function ProductSummaryWrapper({
       <ProductSummaryCustom
         product={product}
         href={href}
+        target={target}
         actionOnClick={actionOnClick}
         priceBehavior={priceBehavior}
         position={position}


### PR DESCRIPTION
#### What problem is this solving?

The "product-summary.shelf" block cards when clicked only allows to open the link inside the same browser tab. Adding the prop "target" is possible to open the link inside a new tab.

#### How to test it?

By clicking on the add to cart button a modal with the block "product-summary.shelf" will appear.

[Workspace](https://prproductsummary--frwhirlpool.myvtex.com/lavelinge-hublot-posable-whirlpool-9-0-kg-ffbs-9458-wv-fr-859991636780/p)

#### Screenshots or example usage:

Inside the page, click on this button: 
![image](https://user-images.githubusercontent.com/57952473/139286468-e95083b8-0f0a-4345-a909-5d1f5eb5512e.png)
This will open the modal: 
![image](https://user-images.githubusercontent.com/57952473/139286605-832f159d-feb1-4153-b3da-a5eb6667d1f3.png)
when the cards are clicked, a new tab will be opened.

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
