### PR TITLE
new component: Product category link. it links into the product's cat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## -2021-12-10
+- added new component: Product Category link to allow navigating into a category from a product shelf or search result.
+- 
 ## [2.77.1] - 2021-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ## -2021-12-10
-- added new component: Product Category link to allow navigating into a category from a product shelf or search result.
-- 
+### added 
+- new component: Product Category link to allow navigating into a category from a product shelf or search result.
+
 ## [2.77.1] - 2021-10-08
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Now, you are able to use all blocks exported by the `product-summary` app. Check
 | `product-summary-price` | ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red) The Product Summary Price block, responsible for rendering the product price, has been deprecated in favor of the [Product Price](https://vtex.io/docs/components/all/vtex.product-price/) app. Although support for this block is still granted, we strongly recommend you to use the Product Price app's blocks instead. | 
 | [`product-summary-sku-selector`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-sku-selector) | Renders the SKU Selector block. | 
 | [`product-specification-badges`](https://vtex.io/docs/components/all/vtex.product-summary/product-summary-specification-badges) | Renders badges based on the product specifications. |
+| `product-summary-category-link` | Renders a link to the product's category page. |
 
 2. Add the `list-context.product-list` block to the store theme template where you desire to display a product list and declare the `product-summary.shelf` in its block list. For example:
 
@@ -60,6 +61,7 @@ Now, you are able to use all blocks exported by the `product-summary` app. Check
     "children": [
       "product-summary-name",
       "product-summary-description",
+      "product-summary-category-link",
       "product-summary-image",
       "product-summary-price",
       "product-summary-sku-selector",
@@ -97,8 +99,11 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `priceContainer`           |
 | `quantityStepperContainer` |
 | `spacer`                   |
+| `categoryLink` |
+| `categoryLinkContainer`                   |
 
 <!-- DOCS-IGNORE:start -->
+
 
 ## Contributors ✨
 

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -17,7 +17,7 @@ interface Props {
   classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
-function ProductSummaryCategoryLink({ classes } : Props) {
+function ProductSummaryCategoryLink({ classes }: Props) {
   const { product, isLoading } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const mylink = buildLink(product)
@@ -48,7 +48,7 @@ function ProductSummaryCategoryLink({ classes } : Props) {
         onKeyPress={blocklink}
       >
        {lastcat}
-      </a>
+       </a>
     )
   }
 

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -47,8 +47,8 @@ function ProductSummaryCategoryLink({ classes }: Props) {
         onClick={blocklink}
         onKeyPress={blocklink}
       >
-       {lastcat}
-       </a>
+        {lastcat}
+      </a>
     )
   }
 

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -10,16 +10,9 @@ const { useProductSummary } = ProductSummaryContext
 const CSS_HANDLES = [
   'categoryLink',
   'categoryLinkContainer',
-  'loading'
-  
-] as const
-
-
-
-
+  'loading' ] as const
 
 interface Props {
-  
   classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
@@ -29,8 +22,7 @@ function ProductSummaryCategoryLink({
 }: Props) {
   const { product, isLoading } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
-
-  const mylink = buildLink(product);
+  const mylink = buildLink(product)
   if (isLoading ) {
     return (
       <div
@@ -40,21 +32,18 @@ function ProductSummaryCategoryLink({
       </div>
     )
   }
-function blocklink(e: any){
-  e.stopPropagation();
   
-}
+  function blocklink(e: any){
+    e.stopPropagation();
+  }
 
-function buildLink(product: any){
-  const categories = product?.categories[0];
-  let lastcat = categories.split("/");
-  const url= categories.toLowerCase().replace(/[ &]/g, '-');
-  lastcat=lastcat[lastcat.length-2];
-
-  return (<a href={url} className={handles.categoryLink}>{lastcat}</a>)
-
-
-}
+  function buildLink(product: any){
+    const categories = product?.categories[0];
+    let lastcat = categories.split("/");
+    const url= categories.toLowerCase().replace(/[ &]/g, '-');
+    lastcat=lastcat[lastcat.length-2];
+    return (<a href={url} className={handles.categoryLink}>{lastcat}</a>)
+  }
 
 
   return (
@@ -63,7 +52,5 @@ function buildLink(product: any){
     </div>
   )
 }
-
-
-
+  
 export default ProductSummaryCategoryLink

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -2,28 +2,27 @@ import React from 'react'
 import { ProductSummaryContext } from 'vtex.product-summary-context'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
-import styles from './productSummary.css'
 
+import styles from './productSummary.css'
 
 const { useProductSummary } = ProductSummaryContext
 
 const CSS_HANDLES = [
   'categoryLink',
   'categoryLinkContainer',
-  'loading' ] as const
+  'loading',
+] as const
 
 interface Props {
   classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
 
-function ProductSummaryCategoryLink({
-  classes,
-}: Props) {
+function ProductSummaryCategoryLink( { classes } : Props) {
   const { product, isLoading } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
-  const mylink = buildLink(product)
-  if (isLoading ) {
+  const mylink = buildLink()
+  if (isLoading) {
     return (
       <div
         className={`${handles.loading} flex items-end justify-end w-100 h1 pr6`}
@@ -32,25 +31,26 @@ function ProductSummaryCategoryLink({
       </div>
     )
   }
-  
-  function blocklink(e: any){
-    e.stopPropagation();
+
+  function blocklink(e: any) {
+    e.stopPropagation()
   }
 
-  function buildLink(product: any){
-    const categories = product?.categories[0];
-    let lastcat = categories.split("/");
-    const url= categories.toLowerCase().replace(/[ &]/g, '-');
-    lastcat=lastcat[lastcat.length-2];
-    return (<a href={url} className={handles.categoryLink}>{lastcat}</a>)
+  function buildLink() {
+    const categories = product?.categories[0]
+    let lastcat = categories.split('/');
+    const url = categories.toLowerCase().replace(/[ &]/g, '-');
+    lastcat = lastcat[lastcat.length-2];
+    return (
+      ······<a href={url} className={handles.categoryLink}>{lastcat}</a>
+    )
   }
-
 
   return (
-    <div className={handles.categoryLinkContainer} onClick={blocklink}>
-        {mylink}
+    <div role="link" onKeyPress={blocklink} className={handles.categoryLinkContainer} onClick={blocklink}>
+      {mylink}
     </div>
   )
 }
-  
+
 export default ProductSummaryCategoryLink

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -17,8 +17,7 @@ interface Props {
   classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
-
-function ProductSummaryCategoryLink( { classes } : Props) {
+function ProductSummaryCategoryLink({ classes } : Props) {
   const { product, isLoading } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const mylink = buildLink(product)

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -42,7 +42,7 @@ function ProductSummaryCategoryLink( { classes } : Props) {
     const url = categories.toLowerCase().replace(/[ &]/g, '-');
     lastcat = lastcat[lastcat.length-2];
     return (
-      ······<a href={url} className={handles.categoryLink}>{lastcat}</a>
+            <a href={url} className={handles.categoryLink}>{lastcat}</a>
     )
   }
 

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -48,10 +48,11 @@ function ProductSummaryCategoryLink( { classes } : Props) {
 
   return (
     <div
-      role="layout"
+      role="widget"
       onKeyPress={blocklink}
       className={handles.categoryLinkContainer}
-      onClick={blocklink}>
+      onClick={blocklink}
+    >
       {mylink}
     </div>
   )

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -38,16 +38,20 @@ function ProductSummaryCategoryLink( { classes } : Props) {
 
   function buildLink(pr: any) {
     const categories = pr?.categories[0]
-    let lastcat = categories.split('/');
-    const url = categories.toLowerCase().replace(/[ &]/g, '-');
-    lastcat = lastcat[lastcat.length-2];
+    let lastcat = categories.split('/')
+    const url = categories.toLowerCase().replace(/[ &]/g, '-')
+    lastcat = lastcat[lastcat.length - 2]
     return (
-            <a href={url} className={handles.categoryLink}>{lastcat}</a>
+      <a href={url} className={handles.categoryLink}>{lastcat}</a>
     )
   }
 
   return (
-    <div role="link" onKeyPress={blocklink} className={handles.categoryLinkContainer} onClick={blocklink}>
+    <div
+      role="layout"
+      onKeyPress={blocklink}
+      className={handles.categoryLinkContainer}
+      onClick={blocklink}>
       {mylink}
     </div>
   )

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -21,7 +21,7 @@ interface Props {
 function ProductSummaryCategoryLink( { classes } : Props) {
   const { product, isLoading } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
-  const mylink = buildLink()
+  const mylink = buildLink(product)
   if (isLoading) {
     return (
       <div
@@ -36,8 +36,8 @@ function ProductSummaryCategoryLink( { classes } : Props) {
     e.stopPropagation()
   }
 
-  function buildLink() {
-    const categories = product?.categories[0]
+  function buildLink(pr: any) {
+    const categories = pr?.categories[0]
     let lastcat = categories.split('/');
     const url = categories.toLowerCase().replace(/[ &]/g, '-');
     lastcat = lastcat[lastcat.length-2];

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -42,16 +42,21 @@ function ProductSummaryCategoryLink( { classes } : Props) {
     const url = categories.toLowerCase().replace(/[ &]/g, '-')
     lastcat = lastcat[lastcat.length - 2]
     return (
-      <a href={url} className={handles.categoryLink}>{lastcat}</a>
+      <a 
+        href={url}
+        role="link"
+        className={handles.categoryLink}
+        onClick={blocklink}
+        onKeyPress={blocklink}
+       >
+        {lastcat}
+      </a>
     )
   }
 
   return (
     <div
-      role="button"
-      onKeyPress={blocklink}
       className={handles.categoryLinkContainer}
-      onClick={blocklink}
     >
       {mylink}
     </div>

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -42,24 +42,19 @@ function ProductSummaryCategoryLink( { classes } : Props) {
     const url = categories.toLowerCase().replace(/[ &]/g, '-')
     lastcat = lastcat[lastcat.length - 2]
     return (
-      <a 
+      <a
         href={url}
-        role="link"
         className={handles.categoryLink}
         onClick={blocklink}
         onKeyPress={blocklink}
        >
-        {lastcat}
+       {lastcat}
       </a>
     )
   }
 
   return (
-    <div
-      className={handles.categoryLinkContainer}
-    >
-      {mylink}
-    </div>
+    <div className={handles.categoryLinkContainer}>{mylink}</div>
   )
 }
 

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -48,7 +48,7 @@ function ProductSummaryCategoryLink( { classes } : Props) {
 
   return (
     <div
-      role="widget"
+      role="button"
       onKeyPress={blocklink}
       className={handles.categoryLinkContainer}
       onClick={blocklink}

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+
+
+import { ProductSummaryContext } from 'vtex.product-summary-context'
+
+import { useCssHandles } from 'vtex.css-handles'
+import type { CssHandlesTypes } from 'vtex.css-handles'
+
+import styles from './productSummary.css'
+
+
+const { useProductSummary } = ProductSummaryContext
+
+const CSS_HANDLES = [
+  'categoryLink',
+  'categoryLinkContainer',
+  'loading'
+  
+] as const
+
+
+
+
+
+interface Props {
+  
+  classes: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+}
+
+
+function ProductSummaryCategoryLink({
+  classes,
+}: Props) {
+  const { product, isLoading } = useProductSummary()
+  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+
+  const mylink = buildLink(product);
+  if (isLoading ) {
+    return (
+      <div
+        className={`${handles.loading} flex items-end justify-end w-100 h1 pr6`}
+      >
+        <div className={styles.priceSpinner} />
+      </div>
+    )
+  }
+function blocklink(e: any){
+  e.stopPropagation();
+  
+}
+
+function buildLink(product: any){
+  const categories = product?.categories[0];
+  let lastcat = categories.split("/");
+  const url= categories.toLowerCase().replace(/[ &]/g, '-');
+  lastcat=lastcat[lastcat.length-2];
+
+  return (<a href={url} className={handles.categoryLink}>{lastcat}</a>)
+
+
+}
+
+
+  return (
+    <div className={handles.categoryLinkContainer} onClick={blocklink}>
+        {mylink}
+    </div>
+  )
+}
+
+
+
+export default ProductSummaryCategoryLink

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -46,15 +46,13 @@ function ProductSummaryCategoryLink({ classes } : Props) {
         className={handles.categoryLink}
         onClick={blocklink}
         onKeyPress={blocklink}
-       >
+      >
        {lastcat}
       </a>
     )
   }
 
-  return (
-    <div className={handles.categoryLinkContainer}>{mylink}</div>
-  )
+  return <div className={handles.categoryLinkContainer}>{mylink}</div>
 }
 
 export default ProductSummaryCategoryLink

--- a/react/ProductSummaryCategoryLink.tsx
+++ b/react/ProductSummaryCategoryLink.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
-
-
-
 import { ProductSummaryContext } from 'vtex.product-summary-context'
-
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
-
 import styles from './productSummary.css'
 
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -99,5 +99,9 @@
     "allowed": ["product-summary"],
     "composition": "children",
     "component": "ProductSummaryListWithoutQuery"
+  },
+
+  "product-summary-category-link": {
+    "component": "ProductSummaryCategoryLink"
   }
 }


### PR DESCRIPTION
…egory

#### What problem is this solving?

IBK Bike (new integration) requested to have the category link available in product shelfs. Instead of building something custom, i thought this is generally handy to bump up the user navigation success and making them find what they are looking for. 

This allows users to jump into category pages from wherever they might find a product summary. This is including Homepage, search results, category or brand pages etc. 

#### How to test it?

Easy! Go to my workspace and find the link to the category in the product summary.

[kaibrockelt appliancetheme](https://kaibrockelt--appliancetheme.myvtex.com/small-appliances)

#### Screenshots or example usage:

`````diff
"product-summary.shelf": {
    "children": [
      "stack-layout#prodsum",
      "product-summary-name",
+      "product-summary-category-link",
      "flex-layout.col#productRating",
      "product-summary-space",
      "product-list-price#summary",
      "flex-layout.row#selling-price-savings",
      "product-installments#summary",
      "add-to-cart-button"
    ]
  },
`````


Renders into: 
![CategoryLink](https://user-images.githubusercontent.com/93577143/145616541-a56ac0f8-5612-4fa0-ab18-297332fbdcd0.png)

#### Describe alternatives you've considered, if any.

Building this with a store link failed on dynamically adding the category's name.

#### Related to / Depends on

nothing. its a newly exposed block with no props to configure except for the custom css class.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media4.giphy.com/media/UogSmj4xDjQZO/giphy.gif?cid=ecf05e47ha3gqji0ajjornok219b4324fe758t11jjpnp8iv&rid=giphy.gif&ct=g)
