### PR TITLE
Update ProductSummaryAttachmentList.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Doc: Product Summary Attachment List - fixed the block name to be added into the app theme.
+
 ## [2.78.0] - 2022-01-06
 
 ### Fixed

--- a/docs/ProductSummaryAttachmentList.md
+++ b/docs/ProductSummaryAttachmentList.md
@@ -8,7 +8,7 @@ _Product Summary Attachment List_ renders the assembly options added and removed
 
 You should follow the usage instruction in the main [README](https://github.com/vtex-apps/product-summary/blob/master/README.md#usage).
 
-Then, add `product-summary-sku-name` block into your app theme as children of `product-summary.shelf`, as we do in our [Product Summary app](https://github.com/vtex-apps/product-summary/blob/master/store/blocks.json).
+Then, add `product-summary-attachment-list` block into your app theme as children of `product-summary.shelf`, as we do in our [Product Summary app](https://github.com/vtex-apps/product-summary/blob/master/store/blocks.json).
 
 ```diff
    "product-summary.shelf": {


### PR DESCRIPTION
#### What problem is this solving?

In the **Product Summary Attachment List** doc, the _Configuration_ section guides the user to add the `product-summary-sku-name` block. However, the `product-summary-attachment-list` block should be added as children of `product-summary.shelf`. This PR fixes this information.