### PR TITLE
Use h3 by default instead of h1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- SEO: Use `h3` as default tag for `ProductSummaryName` instead of `h1` 
+
 ## [2.80.0] - 2022-05-27
 
 ### Added

--- a/react/ProductSummaryName.tsx
+++ b/react/ProductSummaryName.tsx
@@ -33,7 +33,7 @@ interface Props {
   }
   /**
    * HTML tag used. It can be: `div`, `h1`, `h2`, `h3`.
-   * @default "h1"
+   * @default "h3"
    */
   tag?: 'div' | 'h1' | 'h2' | 'h3'
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
@@ -41,7 +41,7 @@ interface Props {
 
 function ProductSummaryName({
   showFieldsProps = defaultShowFields,
-  tag = 'h1',
+  tag = 'h3',
   classes,
 }: Props) {
   const { product } = useProductSummary()


### PR DESCRIPTION
#### What problem is this solving?

Although Google has said that technically there is nothing wrong with having multiple H1 tags on a page, it is still W3C best practice to limit each page to one H1 tag. Having a single H1 tag helps make the page more semantic and accessible (for instance with users of screen readers). This PR changes the default tag for the `ProductSummaryName` to `h3` instead of `h1` (the thought process being that the title of the PLP would be an `h1`, then there may be a content area with an `h2`, then each product's name becomes an `h3`). 

#### How to test it?

Linked here: https://h3test--esika.myvtex.com/maquillaje/c