### PR TITLE
feat: add experimentalSetExplicitDimensions prop

### DIFF
--- a/docs/ProductSummaryImage.md
+++ b/docs/ProductSummaryImage.md
@@ -56,6 +56,7 @@
 | `hoverImage` | `object` | Defines which criteria should be used to define the hover image according to the product images in the admin's Catalog. | `undefined`|
 | `width` | `object` | Defines the Product Summary Image width. | `undefined` |
 | `height` | `object` | Defines the Product Summary Image height. | `undefined` |
+| `experimentalSetExplicitDimensions` | `boolean` | Experimental property to apply `width` and `height` props in HTML tag attribute values | `false` |
 | `aspectRatio` | `object` | Aspect ratio of the Product Summary Image. It defines whether the image should be displayed in a square, portrait, landscape or in another format. The prop value should follow the [common aspect ratio notation](https://en.wikipedia.org/wiki/Aspect_ratio_(image)), which gives two numbers separated by a colon. For example: `1:1` for a square format or `3:4` for an upright portrait. Note that this prop won't work if you've already configured the `width` or `height` props. | `undefined` |
 | `maxHeight` | `object` | Defines the Product Summary Image max height. Note that this prop won't work if you've already configured the `width` or `height` props.| `undefined` |
 

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -219,6 +219,7 @@ interface ImageProps {
   className: string
   aspectRatio?: string | number
   maxHeight?: string
+  experimentalSetExplicitDimensions?: boolean
 }
 
 function Image({
@@ -230,6 +231,7 @@ function Image({
   className,
   aspectRatio,
   maxHeight,
+  experimentalSetExplicitDimensions,
 }: ImageProps) {
   const { isMobile } = useDevice()
 
@@ -244,6 +246,16 @@ function Image({
 
   const shouldResize = !!(width || height)
 
+  const widthWithoutUnits = width ? width.toString().replace(/\D/g, '') : null
+  const heightWithoutUnits = height
+    ? height.toString().replace(/\D/g, '')
+    : null
+
+  const explicitDimensionsAreAvailable =
+    !width?.toString().includes('%') &&
+    !height?.toString().includes('%') &&
+    (widthWithoutUnits || heightWithoutUnits)
+
   return (
     <img
       src={getImageSrc({ src, width, height, dpi, aspectRatio })}
@@ -253,6 +265,12 @@ function Image({
       alt={alt}
       className={className}
       onError={onError}
+      {...(experimentalSetExplicitDimensions && explicitDimensionsAreAvailable
+        ? {
+            width: widthWithoutUnits ?? undefined,
+            height: heightWithoutUnits ?? undefined,
+          }
+        : {})}
     />
   )
 }
@@ -292,6 +310,7 @@ interface Props {
   aspectRatio?: ResponsiveValuesTypes.ResponsiveValue<string | number>
   maxHeight?: ResponsiveValuesTypes.ResponsiveValue<string>
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  experimentalSetExplicitDimensions?: boolean
 }
 
 function ProductImage({
@@ -308,6 +327,7 @@ function ProductImage({
   aspectRatio: aspectRatioProp,
   maxHeight: maxHeightProp,
   classes,
+  experimentalSetExplicitDimensions,
 }: Props) {
   const { product } = useProductSummary()
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
@@ -440,6 +460,9 @@ function ProductImage({
               alt={name}
               className={imageClassname}
               onError={onError}
+              experimentalSetExplicitDimensions={
+                experimentalSetExplicitDimensions
+              }
             />
             {selectedHoverImage && !isMobile && (
               <Image
@@ -451,6 +474,9 @@ function ProductImage({
                 alt={name}
                 className={hoverImageClassname}
                 onError={onError}
+                experimentalSetExplicitDimensions={
+                  experimentalSetExplicitDimensions
+                }
               />
             )}
           </div>


### PR DESCRIPTION
#### What problem is this solving?

Not using HTML attributes for `width` and `height` impacts directly on SEO.

#### Describe alternatives you've considered, if any.

Replacing the custom Image component here for store-image one would make everything connected and easier to maintain. Should be considered for future versions.

#### Related to / Depends on

Relates to vtex.store-image recent update where it adds this exact same flag, which I basically copied from.
