### PR TITLE
Add `rootPath` handling in useSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adds `rootPath` to Session API requests.
 
 ## [2.83.1] - 2023-05-03
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.83.1",
+  "version": "2.83.2-beta.0",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-summary",
-  "version": "2.83.2-beta.0",
+  "version": "2.83.1",
   "title": "Product Summary",
   "description": "Product summary component",
   "defaultLocale": "pt-BR",

--- a/react/hooks/useSession.ts
+++ b/react/hooks/useSession.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
 
 const useSession = () => {
+  const { rootPath } = useRuntime()
+
   const getShippingOptionFromSession = useCallback(async () => {
     const headers = new Headers()
 
@@ -13,7 +16,7 @@ const useSession = () => {
     }
 
     const session = await fetch(
-      '/api/sessions?items=public.shippingOption',
+      `${rootPath}/api/sessions?items=public.shippingOption`,
       requestOptions
     )
 

--- a/react/hooks/useSession.ts
+++ b/react/hooks/useSession.ts
@@ -16,7 +16,7 @@ const useSession = () => {
     }
 
     const session = await fetch(
-      `${rootPath}/api/sessions?items=public.shippingOption`,
+      `${rootPath ?? ''}/api/sessions?items=public.shippingOption`,
       requestOptions
     )
 

--- a/react/hooks/useSession.ts
+++ b/react/hooks/useSession.ts
@@ -29,7 +29,7 @@ const useSession = () => {
     return JSON.parse(data.namespaces.public.shippingOption.value)?.map(
       (option: { key: string; value: string }) => option.value
     )
-  }, [])
+  }, [rootPath])
 
   return { getShippingOptionFromSession }
 }


### PR DESCRIPTION
#### What problem is this solving?
Sessions APIs request didn't consider the `rootPath` when building the URL, then the requests return an error 404.

<!--- What is the motivation and context for this change? -->

#### How to test it?
It should be tested in public domains because there's no `rootPath` in "myvtex", it's a CDN routing thing. I created two workspaces with Store Theme to ease the visualization.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[With my improvement](https://dev55.angeloni.com.br/super/?workspace=usesessionwithrootpath)
[Without my improvement](https://dev55.angeloni.com.br/super/?workspace=usesessionwithoutrootpath)

The page should be scrolled to the first shelf because there are other Sessions requests from another component.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: before and after images -->
* Improved
![image](https://user-images.githubusercontent.com/27451066/236559635-d539d2f6-0c23-46d4-bba8-bf235eefb5f9.png)

* Not improved 
![image](https://user-images.githubusercontent.com/27451066/236559959-e16d3151-7bf7-45b3-9526-7e8a2eeb910c.png)

* Ensure the caller
![image](https://user-images.githubusercontent.com/27451066/236559692-975f87cc-9386-4da3-a7d6-d4e3146dbb28.png)



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
