### PR TITLE
feat: Added a prop to set the max description dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a prop to set the max description dynamically
+
 ## [2.83.5] - 2023-07-05
 
 ### Fixed

--- a/react/ProductSummaryDescription.tsx
+++ b/react/ProductSummaryDescription.tsx
@@ -11,10 +11,10 @@ const CSS_HANDLES = ['description'] as const
 
 interface Props {
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
-  maxSizeDescription?: number
+  descriptionMaxSize?: number
 }
 
-function ProductSummaryDescription({ classes, maxSizeDescription }: Props) {
+function ProductSummaryDescription({ classes, descriptionMaxSize }: Props) {
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 
   const {
@@ -27,7 +27,7 @@ function ProductSummaryDescription({ classes, maxSizeDescription }: Props) {
 
   const descriptionClasses = `${handles.description} c-muted-2 t-small`
 
-  const maxSize = maxSizeDescription ?? MAX_SIZE_DESCRIPTION
+  const maxSize = descriptionMaxSize ?? MAX_SIZE_DESCRIPTION
   const descriptionTruncated =
     description.length > maxSize
       ? `${description.substring(0, maxSize)}...`

--- a/react/ProductSummaryDescription.tsx
+++ b/react/ProductSummaryDescription.tsx
@@ -11,9 +11,10 @@ const CSS_HANDLES = ['description'] as const
 
 interface Props {
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  maxSizeDescription?: number
 }
 
-function ProductSummaryDescription({ classes }: Props) {
+function ProductSummaryDescription({ classes, maxSizeDescription }: Props) {
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
 
   const {
@@ -26,9 +27,10 @@ function ProductSummaryDescription({ classes }: Props) {
 
   const descriptionClasses = `${handles.description} c-muted-2 t-small`
 
+  const maxSize = maxSizeDescription ?? MAX_SIZE_DESCRIPTION
   const descriptionTruncated =
-    description.length > MAX_SIZE_DESCRIPTION
-      ? `${description.substring(0, MAX_SIZE_DESCRIPTION)}...`
+    description.length > maxSize
+      ? `${description.substring(0, maxSize)}...`
       : description
 
   return (


### PR DESCRIPTION
#### What problem is this solving?

It has been added a way to set the max description which is hardcoded by a constant (120).

This way is possible to set a new property on the **Product Description Component** which makes it possible to set it on the theme blocks.

#### How to test it?

https://artur2--beautycounterqa.myvtex.com/

#### Screenshots or example usage:

<img width="578" alt="CleanShot 2023-08-02 at 18 05 52@2x" src="https://github.com/vtex-apps/product-summary/assets/5812946/99942380-041a-4711-ae1e-765e0d229ce6">
