### PR TITLE
Feature: hide sponsored badge label if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Hide sponsored badge label if specified.
+
 ## [2.87.0] - 2023-11-28
 
 ### Added

--- a/react/ProductSummaryName.tsx
+++ b/react/ProductSummaryName.tsx
@@ -54,6 +54,8 @@ function ProductSummaryName({
   const brandName = product?.brand
 
   const isSponsored = !!product?.advertisement?.adId
+  const showSponsoredBadge =
+    isSponsored && product?.advertisement?.options?.showSponsoredBadge
 
   const containerClasses = `${handles.nameContainer} flex items-start justify-center pv6`
   const wrapperClasses = `${handles.nameWrapper} overflow-hidden c-on-base f5`
@@ -68,7 +70,7 @@ function ProductSummaryName({
         brandNameClass={brandNameClasses}
         skuNameClass={skuNameClasses}
         loaderClass={loaderClasses}
-        showSponsoredBadge={isSponsored}
+        showSponsoredBadge={showSponsoredBadge}
         sponsoredBadgeLabel={sponsoredBadgeLabel}
         productReferenceClass={handles.productReference}
         name={productName}


### PR DESCRIPTION
#### What problem is this solving?

If the ad server specifies that the sponsored badge should not be shown, we hide it. This is useful for experiments.
