### PR TITLE
Feature: supports multiple sponsored badge positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support options for different sponsored badge positions.
+
 ## [2.87.1] - 2023-12-19
 
 ### Added

--- a/docs/ProductSummaryName.md
+++ b/docs/ProductSummaryName.md
@@ -42,7 +42,6 @@ Product Summary Name is a block exported by the [Product Summary app](https://de
 | `showSku` | `Boolean` | Show product SKU | `false` |
 | `showProductReference` | `Boolean` | Show product reference | `false`| 
 | `showBrandName` | `Boolean` | Show brand name | `false`| 
-| `sponsoredBadgeLabel` | `String` | The text of the "Sponsored" tag, if applicable. | `"store/sponsored-badge.label"`| 
 
 ## Customization
 

--- a/docs/ProductSummaryShelf.md
+++ b/docs/ProductSummaryShelf.md
@@ -47,6 +47,8 @@ The Product Summary Shelf is the main block exported by the [Product Summary app
 | - | - | - | - |
 | `priceBehavior` |  `enum` | Determines whether the component should fetch the most up-to-date price (`async`) or (`default`). Remember to configure the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s `simulationBehavior` prop to `skip` and use the Product Price [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price information is being fetched. | `default` |
 | `trackListName` | `boolean` | Determines whether the component should send the list name to the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated. | `true` |
+| `sponsoredBadgeLabel` | `String` | The text of the "Sponsored" tag, if applicable. | `"store/sponsored-badge.label"`| 
+| `sponsoredBadgePosition` | `enum` | The text of the "Sponsored" tag, if applicable. Possible values are `titleTop`, `containerTopLeft` and `none`. | `"titleTop"`| 
 
 ## Customization
 

--- a/docs/ProductSummaryShelf.md
+++ b/docs/ProductSummaryShelf.md
@@ -48,7 +48,7 @@ The Product Summary Shelf is the main block exported by the [Product Summary app
 | `priceBehavior` |  `enum` | Determines whether the component should fetch the most up-to-date price (`async`) or (`default`). Remember to configure the [Search Result](https://vtex.io/docs/components/content-blocks/vtex.search-result@3.79.1/#configuration)'s `simulationBehavior` prop to `skip` and use the Product Price [`product-price-suspense`](https://github.com/vtex-apps/product-price/blob/master/docs/README.md) block to render a loading spinner while the price information is being fetched. | `default` |
 | `trackListName` | `boolean` | Determines whether the component should send the list name to the product page when the product summary is clicked. Disabling it will prevent the `productDetail` GTM event sent on the PDP to identify from which list the user navigated. | `true` |
 | `sponsoredBadgeLabel` | `String` | The text of the "Sponsored" tag, if applicable. | `"store/sponsored-badge.label"`| 
-| `sponsoredBadgePosition` | `enum` | The text of the "Sponsored" tag, if applicable. Possible values are `titleTop`, `containerTopLeft` and `none`. | `"titleTop"`| 
+| `sponsoredBadgePosition` | `enum` | The position of the "Sponsored" tag, if applicable. Possible values are `titleTop`, `containerTopLeft` and `none`. | `"titleTop"`| 
 
 ## Customization
 

--- a/messages/ar-SA.json
+++ b/messages/ar-SA.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "تسمية الصورة الفوقية",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "معايير البحث عن تسمية صورة فوقية (بالضبط: العثور على الصورة التي تطابق تماما الاسم المملوء في حقل 'تسمية صورة فوقية' | تضمن: العثور على الصورة الأولى التي تحتوي على النص المملوء في حقل 'تسمية صورة فوقية')",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "مؤشر الصورة الفوقية",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "ข้อความของแท็กผลิตภัณฑ์ที่ได้รับการสนับสนุน หากมี",
   "admin/editor.productSummaryBuyButton.title": "زر ملخص شراء المنتج",
   "admin/editor.productSummaryName.title": "اسم ملخص المنتج",
   "admin/editor.product-summary-specification-badges.title": "ملخص مواصفات شارات المنتج",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "الحد الأقصى بدون فوائد",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "الحد الأقصى",
   "admin/editor.productSummaryList.analyticsListName.title": "اسم القائمة في التحليلات",
-  "admin/editor.productSummary.trackListName.title": "يجب أن يكون اسم مسار القائمة"
+  "admin/editor.productSummary.trackListName.title": "يجب أن يكون اسم مسار القائمة",
+  "admin/editor.productSummary.sponsoredBadge.title": "نص علامة المنتج الدعاء ، إن أمكن",
+  "admin/editor.productSummary.sponsoredBadge.position": "موقف علامة المنتج المدعومة ، إن أمكن",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "فوق اسم المنتج",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "فوق حاوية المنتج",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "لا تظهر"
 }

--- a/messages/bg-BG.json
+++ b/messages/bg-BG.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Етикет при задържане на курсора върху изображение",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Критерии за търсене на етикет при задържане на курсора върху изображението (точно: намира изображението, което е точно съвпадение с името, посочено в полето „етикет при задържане на курсора върху изображение“ | съдържа: намира първото изображение, което съдържа текста, поставен в полето „етикет при задържане на курсора върху изображение“)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Индекс при задържане на курсора върху изображение",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Текст на етикета на спонсорирания продукт, ако е приложимо",
   "admin/editor.productSummaryBuyButton.title": "Бутон за покупка с резюме на продукта",
   "admin/editor.productSummaryName.title": "Име на резюме на продукта",
   "admin/editor.product-summary-specification-badges.title": "Значки със спецификации на резюме на продукта",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Максимални без лихва",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Максимални",
   "admin/editor.productSummaryList.analyticsListName.title": "Наименование на списъка в Analytics",
-  "admin/editor.productSummary.trackListName.title": "Трябва да следи наименованието на списъка"
+  "admin/editor.productSummary.trackListName.title": "Трябва да следи наименованието на списъка",
+  "admin/editor.productSummary.sponsoredBadge.title": "Текст на спонсорирания продуктов етикет, ако е приложимо",
+  "admin/editor.productSummary.sponsoredBadge.position": "Позиция на спонсорирания продуктов етикет, ако е приложимо",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Над името на продукта",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Отгоре на контейнера за продукти",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Не показвайте"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -37,7 +37,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "admin/editor.productSummaryImage.hoverImage.criteria.index",
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "admin/editor.productSummaryImage.hoverImage.criteria.label",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "admin/editor.productSummaryName.sponsoredBadge.title",
   "admin/editor.productSummaryBuyButton.title": "admin/editor.productSummaryBuyButton.title",
   "admin/editor.productSummaryName.title": "admin/editor.productSummaryName.title",
   "admin/editor.product-summary-specification-badges.title": "admin/editor.product-summary-specification-badges.title",
@@ -71,5 +70,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest enum name",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum with interest enum name",
   "admin/editor.productSummaryList.analyticsListName.title": "List name in Analytics",
-  "admin/editor.productSummary.trackListName.title": "Should track list name"
+  "admin/editor.productSummary.trackListName.title": "Should track list name",
+  "admin/editor.productSummary.sponsoredBadge.title": "admin/editor.productSummary.sponsoredBadge.title",
+  "admin/editor.productSummary.sponsoredBadge.position": "admin/editor.productSummary.sponsoredBadge.position",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "admin/editor.productSummary.sponsoredBadge.position.titleTop",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "admin/editor.productSummary.sponsoredBadge.position.none"
 }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Mausverschiebung Bildbeschriftung",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Mausverschiebung Bildbeschriftung Bezeichnungssuche (genau: findet das Bild, das genau mit dem Namen übereinstimmt, der im Feld 'Hover Image Label' eingetragen ist | enthält: findet das erste Bild, das den Text enthält, der im Feld 'Hover Image Label' ausgefüllt ist)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Mausverschiebung Index",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Text des gesponserten Produkt-Tags, falls zutreffend",
   "admin/editor.productSummaryBuyButton.title": "Produktübersicht Kauf-Taste",
   "admin/editor.productSummaryName.title": "Produktübersicht Name",
   "admin/editor.product-summary-specification-badges.title": "Produktübersicht Spezifikations-Abzeichen",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum ohne Zinsen",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum",
   "admin/editor.productSummaryList.analyticsListName.title": "Listenname in der Analytik",
-  "admin/editor.productSummary.trackListName.title": "Sollte Listenname anzeigen"
+  "admin/editor.productSummary.trackListName.title": "Sollte Listenname anzeigen",
+  "admin/editor.productSummary.sponsoredBadge.title": "Text des gesponserten Produkts, falls zutreffend",
+  "admin/editor.productSummary.sponsoredBadge.position": "Position des gesponserten Produkts, falls zutreffend",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Über dem Namen des Produkts",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Über den Produktbehälter",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Zeigen Sie nicht"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Hover Image Index",
   "admin/editor.productSummaryBuyButton.title": "Product Summary Buy Button",
   "admin/editor.productSummaryName.title": "Product Summary Name",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Text of the sponsored product tag, if applicable",
   "admin/editor.product-summary-specification-badges.title": "Product Summary Specification Badges",
   "admin/editor.productSummaryList.title": "Product List",
   "admin/editor.productSummaryList.description": "Product list from a collection",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum without interest",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum",
   "admin/editor.productSummaryList.analyticsListName.title": "List name in Analytics",
-  "admin/editor.productSummary.trackListName.title": "Track list name"
+  "admin/editor.productSummary.trackListName.title": "Track list name",
+  "admin/editor.productSummary.sponsoredBadge.title": "Text of the sponsored product tag, if applicable",
+  "admin/editor.productSummary.sponsoredBadge.position": "Position of the sponsored product tag, if applicable",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Above the product's name",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "On top of the product container",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Don't show"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -40,7 +40,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Índice de la imagen activable",
   "admin/editor.productSummaryBuyButton.title": "Botón de compra del resumen del producto",
   "admin/editor.productSummaryName.title": "Nombre del resumen del producto",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Texto de la etiqueta de producto patrocinado, si corresponde",
   "admin/editor.product-summary-specification-badges.title": "Insignias de especificación del resumen del producto",
   "admin/editor.productSummaryList.title": "Lista de productos",
   "admin/editor.productSummaryList.description": "Una lista de productos que tiene una colección",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sin interés",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo",
   "admin/editor.productSummaryList.analyticsListName.title": "Nombre de la lista en Analytics",
-  "admin/editor.productSummary.trackListName.title": "Rastrear el nombre de la lista"
+  "admin/editor.productSummary.trackListName.title": "Rastrear el nombre de la lista",
+  "admin/editor.productSummary.sponsoredBadge.title": "Texto de la insignia de producto patrocinado, si corresponde",
+  "admin/editor.productSummary.sponsoredBadge.position": "Posición de la insignia de producto patrocinado, si corresponde",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Sobre el nombre del producto",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Sobre el container del producto",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "No mostrar"
 }

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Pointer l’étiquette de l’image",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Critères de recherche pour pointer l’étiquette de l’image (exact : trouve l’image correspondant exactement au nom rempli dans le champ 'Pointer l’étiquette de l’image' | contenus : trouve la première image qui contient le texte rempli dans le champ 'Pointer l’étiquette de l’image')",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Pointer l’index de l’image",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Texte de l'étiquette du produit sponsorisé, le cas échéant",
   "admin/editor.productSummaryBuyButton.title": "Bouton d’achat de la synthèse du produit",
   "admin/editor.productSummaryName.title": "Nom de la synthèse du produit",
   "admin/editor.product-summary-specification-badges.title": "Spécification des badges de la synthèse du produit",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum sans intérêt",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum",
   "admin/editor.productSummaryList.analyticsListName.title": "Nom de la liste dans Analyses",
-  "admin/editor.productSummary.trackListName.title": "Suivre la liste des noms"
+  "admin/editor.productSummary.trackListName.title": "Suivre la liste des noms",
+  "admin/editor.productSummary.sponsoredBadge.title": "Texte de la balise de produit sponsorisée, le cas échéant",
+  "admin/editor.productSummary.sponsoredBadge.position": "Position de l'étiquette de produit sponsorisée, le cas échéant",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Au-dessus du nom du produit",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "En plus du conteneur de produit",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Ne montre pas"
 }

--- a/messages/id-ID.json
+++ b/messages/id-ID.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Label Gambar Mengambang",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Kriteria pencarian label gambar mengambang (persis: temukan gambar yang sama persis dengan nama yang terisi di bidang 'Label Gambar Mengambang’| berisi: temukan gambar pertama yang berisi teks yang terisi di bidang 'Label Gambar Mengambang')",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Indeks Gambar Mengambang",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Teks tag produk bersponsor, jika ada",
   "admin/editor.productSummaryBuyButton.title": "Tombol Beli Ringkasan Produk",
   "admin/editor.productSummaryName.title": "Nama Ringkasan Produk",
   "admin/editor.product-summary-specification-badges.title": "Badge Spesifikasi Ringkasan Produk",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maksimum tanpa bunga",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maksimum",
   "admin/editor.productSummaryList.analyticsListName.title": "Nama daftar dalam Analitika",
-  "admin/editor.productSummary.trackListName.title": "Harus melacak nama daftar"
+  "admin/editor.productSummary.trackListName.title": "Harus melacak nama daftar",
+  "admin/editor.productSummary.sponsoredBadge.title": "Teks dari tag produk yang disponsori, jika berlaku",
+  "admin/editor.productSummary.sponsoredBadge.position": "Posisi tag produk yang disponsori, jika berlaku",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Di atas nama produk",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Di atas wadah produk",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Jangan tunjukkan"
 }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Etichetta dell'immagine secondaria",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Criterio di ricerca dell'etichetta dell'immagine secondaria (exact: trova l'immagine che corrisponde esattamente al nome inserito nel campo \"Etichetta dell'immagine secondaria\" | contains: trova la prima immagine che contiene il testo inserito nel campo \"Etichetta dell'immagina secondaria\")",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Indice dell'immagine secondaria",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Testo del tag del prodotto sponsorizzato, se applicabile",
   "admin/editor.productSummaryBuyButton.title": "Pulsante \"Acquista\" nel riepilogo del prodotto",
   "admin/editor.productSummaryName.title": "Nome nel riepilogo del prodotto",
   "admin/editor.product-summary-specification-badges.title": "Badge per le specifiche nel riepilogo del prodotto",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Importo massimo senza interessi",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Importo massimo",
   "admin/editor.productSummaryList.analyticsListName.title": "Nome del listino in \"Analisi\"",
-  "admin/editor.productSummary.trackListName.title": "Serve a tracciare il nome del listino"
+  "admin/editor.productSummary.trackListName.title": "Serve a tracciare il nome del listino",
+  "admin/editor.productSummary.sponsoredBadge.title": "Testo del tag prodotto sponsorizzato, se applicabile",
+  "admin/editor.productSummary.sponsoredBadge.position": "Posizione del tag prodotto sponsorizzato, se applicabile",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Sopra il nome del prodotto",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "In cima al contenitore del prodotto",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Non mostrare"
 }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "マウスオーバー画像ラベル",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "マウスオーバー画像ラベル検索の基準 (すべて一致: 「マウスオーバー画像ラベル」フィールドの名前フィールドとすべて一致する画像を探します | 含む: 「マウスオーバー画像ラベル」フィールドのテキストフィールドを含む最初の画像を探します)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "マウスオーバー画像インデックス",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "スポンサー付き商品タグのテキスト（該当する場合）",
   "admin/editor.productSummaryBuyButton.title": "製品サマリ購入ボタン",
   "admin/editor.productSummaryName.title": "製品サマリ名",
   "admin/editor.product-summary-specification-badges.title": "製品サマリ指定バッジ",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "利息抜き最大値",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "最大値",
   "admin/editor.productSummaryList.analyticsListName.title": "アナリティクスのリスト名",
-  "admin/editor.productSummary.trackListName.title": "リスト名を追跡する"
+  "admin/editor.productSummary.trackListName.title": "リスト名を追跡する",
+  "admin/editor.productSummary.sponsoredBadge.title": "該当する場合、スポンサー付き製品タグのテキスト",
+  "admin/editor.productSummary.sponsoredBadge.position": "該当する場合、スポンサー付き製品タグの位置",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "製品の名前の上",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "製品容器の上",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "見せないでください"
 }

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "호버 이미지 라벨",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "호버 이미지 라벨 검색 조건(정확: '호버 이미지 라벨' 필드에 입력된 이름과 정확히 일치하는 이미지를 찾습니다. | 포함: '호버 이미지 라벨' 필드에 입력된 텍스트를 포함하는 첫 번째 이미지를 찾습니다.)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "호버 이미지 인덱스",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "해당되는 경우 스폰서 제품 태그의 텍스트",
   "admin/editor.productSummaryBuyButton.title": "제품 요약 구매 버튼",
   "admin/editor.productSummaryName.title": "제품 요약 이름",
   "admin/editor.product-summary-specification-badges.title": "제품 요약 사양 배지",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "무이자 최대",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "최대",
   "admin/editor.productSummaryList.analyticsListName.title": "애널리틱스의 목록 이름",
-  "admin/editor.productSummary.trackListName.title": "목록 이름을 추적해야 함"
+  "admin/editor.productSummary.trackListName.title": "목록 이름을 추적해야 함",
+  "admin/editor.productSummary.sponsoredBadge.title": "적용 가능한 경우 스폰서 제품 태그의 텍스트",
+  "admin/editor.productSummary.sponsoredBadge.position": "적용 가능한 경우 스폰서 제품 태그의 위치",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "제품 이름 위",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "제품 컨테이너 위에",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "표시하지 마십시오"
 }

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Aanwijzen afbeeldingslabel",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Zoekcriteria voor afbeeldingslabel zweven (exact: vindt de afbeelding die exact overeenkomt met de naam die is ingevuld in het veld 'Afbeeldingslabel zweven' | bevat: vindt de eerste afbeelding die de tekst bevat die is ingevuld in het veld 'Afbeeldingslabel zweven')",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Aanwijzen afbeeldingsindex",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Tekst van de gesponsorde producttag, indien van toepassing",
   "admin/editor.productSummaryBuyButton.title": "Productoverzicht koopknop",
   "admin/editor.productSummaryName.title": "Productoverzicht naam",
   "admin/editor.product-summary-specification-badges.title": "Productoverzicht specificatiebadges",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximaal zonder rente",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum",
   "admin/editor.productSummaryList.analyticsListName.title": "Lijstnaam in Analytics",
-  "admin/editor.productSummary.trackListName.title": "Moet lijstnaam volgen"
+  "admin/editor.productSummary.trackListName.title": "Moet lijstnaam volgen",
+  "admin/editor.productSummary.sponsoredBadge.title": "Tekst van de gesponsorde producttag, indien van toepassing",
+  "admin/editor.productSummary.sponsoredBadge.position": "Positie van de gesponsorde producttag, indien van toepassing",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Boven de naam van het product",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Bovenop de productcontainer",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Niet laten zien"
 }

--- a/messages/nn-NO.json
+++ b/messages/nn-NO.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Pek med musepekeren på bildeetikett",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Søkekriterier for pek med musepekeren på bildeetikett (nøyaktig: finner bildet som samsvarer nøyaktig med navnet fylt ut i feltet \"Pek med musepekeren på bildeetikett\" | inneholder: finner det første bildet som inneholder teksten fylt ut i \"Pek med musepekeren på bildeetikett\" -feltet)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Indeks for Pek med musepekeren på bildet",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Tekst til den sponsede produktetiketten, hvis aktuelt",
   "admin/editor.productSummaryBuyButton.title": "Kjøpsknapp for produktsammendrag",
   "admin/editor.productSummaryName.title": "Navn på produktsammendrag",
   "admin/editor.product-summary-specification-badges.title": "Spesifikasjonsmerker for produktsammendrag",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maksimum uten renter",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maksimum",
   "admin/editor.productSummaryList.analyticsListName.title": "Listenavn i Analytics",
-  "admin/editor.productSummary.trackListName.title": "Bør navn på sporliste"
+  "admin/editor.productSummary.trackListName.title": "Bør navn på sporliste",
+  "admin/editor.productSummary.sponsoredBadge.title": "Tekst av den sponsede produktkoden, hvis aktuelt",
+  "admin/editor.productSummary.sponsoredBadge.position": "Plassering av den sponsede produkttaggen, hvis aktuelt",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Over produktets navn",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "På toppen av produktbeholderen",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Ikke vis"
 }

--- a/messages/no-NO.json
+++ b/messages/no-NO.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Pek med musepekeren på bildeetikett",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Søkekriterier for pek med musepekeren på bildeetikett (nøyaktig: finner bildet som samsvarer nøyaktig med navnet fylt ut i feltet \"Pek med musepekeren på bildeetikett\" | inneholder: finner det første bildet som inneholder teksten fylt ut i \"Pek med musepekeren på bildeetikett\" -feltet)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Indeks for Pek med musepekeren på bildet",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Tekst til den sponsede produktetiketten, hvis aktuelt",
   "admin/editor.productSummaryBuyButton.title": "Kjøpsknapp for produktsammendrag",
   "admin/editor.productSummaryName.title": "Navn på produktsammendrag",
   "admin/editor.product-summary-specification-badges.title": "Spesifikasjonsmerker for produktsammendrag",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maksimum uten renter",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maksimum",
   "admin/editor.productSummaryList.analyticsListName.title": "Listenavn i Analytics",
-  "admin/editor.productSummary.trackListName.title": "Bør navn på sporliste"
+  "admin/editor.productSummary.trackListName.title": "Bør navn på sporliste",
+  "admin/editor.productSummary.sponsoredBadge.title": "Tekst av den sponsede produktkoden, hvis aktuelt",
+  "admin/editor.productSummary.sponsoredBadge.position": "Plassering av den sponsede produkttaggen, hvis aktuelt",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Over produktets navn",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "På toppen av produktbeholderen",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Ikke vis"
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Etiqueta da imagem secundária",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Critério de busca da etiqueta da imagem secundária (exato: busca pelo nome exato definido em \"Etiqueta da imagem secundária\" | contém: busca a primeira imagem que contém o texto definido em \"Etiqueta da imagem secundária\")",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Número da imagem secundária",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Texto da tag indicativa de produto patrocinado, se aplicável",
   "admin/editor.productSummaryBuyButton.title": "Botão de compra do resumo do produto",
   "admin/editor.productSummaryName.title": "Nome do resumo do produto",
   "admin/editor.product-summary-specification-badges.title": "Selos de especificação do resumo do produto",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sem juros",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo",
   "admin/editor.productSummaryList.analyticsListName.title": "Nome da lista no Analytics",
-  "admin/editor.productSummary.trackListName.title": "Rastreia o nome da lista"
+  "admin/editor.productSummary.trackListName.title": "Rastreia o nome da lista",
+  "admin/editor.productSummary.sponsoredBadge.title": "Texto da tag de produto patrocinado, se aplicável",
+  "admin/editor.productSummary.sponsoredBadge.position": "Posição da tag de produto patrocinado",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Acima do nome do produto",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Acima do container do produto",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Não mostrar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Etiqueta da imagem secundária",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Critério de busca da etiqueta da imagem secundária (exato: busca pelo nome exato definido em \"Etiqueta da imagem secundária\" | contém: busca a primeira imagem que contém o texto definido em \"Etiqueta da imagem secundária\")",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Número da imagem secundária",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Texto do selo indicativo de produto patrocinado, se aplicável",
   "admin/editor.productSummaryBuyButton.title": "Botão de compra do resumo do produto",
   "admin/editor.productSummaryName.title": "Nome do resumo do produto",
   "admin/editor.product-summary-specification-badges.title": "Selos de especificação do resumo do produto",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Máximo sem juros",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Máximo",
   "admin/editor.productSummaryList.analyticsListName.title": "Nome da lista no Analytics",
-  "admin/editor.productSummary.trackListName.title": "Rastreia o nome da lista"
+  "admin/editor.productSummary.trackListName.title": "Rastreia o nome da lista",
+  "admin/editor.productSummary.sponsoredBadge.title": "Texto da etiqueta de produto patrocinado, se aplicável",
+  "admin/editor.productSummary.sponsoredBadge.position": "Posição da etiqueta de produto patrocinado",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Acima do nome do produto",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Acima do container do produto",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Não mostrar"
 }

--- a/messages/ro-RO.json
+++ b/messages/ro-RO.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "Eticheta imaginii secundare",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "Criteriu de căutare al etichetei imaginii secundare (exact: găsește imaginea care se potrivește perfect cu denumirea completată în câmpul „Etichetă imagine secundară” | contains: găsește prima imagine care conține textul complet în câmpul „Etichetă imagine secundară”)",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "Indexul imaginii secundare",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "Textul etichetei produsului sponsorizat, dacă este cazul",
   "admin/editor.productSummaryBuyButton.title": "Rezumat produs Buton cumpărare",
   "admin/editor.productSummaryName.title": "Denumire rezumat produs",
   "admin/editor.product-summary-specification-badges.title": "Rezumat produs Badge-uri specificații",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "Maximum fără dobândă",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "Maximum",
   "admin/editor.productSummaryList.analyticsListName.title": "Numele listei în Analytics",
-  "admin/editor.productSummary.trackListName.title": "Trebuie monitorizată denumirea listei"
+  "admin/editor.productSummary.trackListName.title": "Trebuie monitorizată denumirea listei",
+  "admin/editor.productSummary.sponsoredBadge.title": "Textul etichetei de produs sponsorizat, dacă este cazul",
+  "admin/editor.productSummary.sponsoredBadge.position": "Poziția etichetei de produs sponsorizate, dacă este cazul",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "Deasupra numelui produsului",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "Deasupra containerului de produs",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "Nu arăta"
 }

--- a/messages/th-TH.json
+++ b/messages/th-TH.json
@@ -38,7 +38,6 @@
   "admin/editor.productSummaryImage.hoverImage.criteria.label": "ป้ายข้อความภาพโฮเวอร์",
   "admin/editor.productSummaryImage.hoverImage.criteria.matchCriteria": "เกณฑ์การค้นหาป้ายข้อความภาพโฮเวอร์ (ทุกประการ: หารูปภาพที่มีค่าตรงกันทุกประการกับชื่อที่กรอกไว้ในฟิลด์ \"ป้ายข้อความภาพโฮเวอร์\" | มี: หารูปภาพแรกที่มีข้อความที่กรอกไว้ในฟิลด์ \"ป้ายข้อความภาพโฮเวอร์\")",
   "admin/editor.productSummaryImage.hoverImage.criteria.index": "ดัชนีภาพโฮเวอร์",
-  "admin/editor.productSummaryName.sponsoredBadge.title": "ข้อความของแท็กผลิตภัณฑ์ที่ได้รับการสนับสนุน หากมี",
   "admin/editor.productSummaryBuyButton.title": "ปุ่มซื้อภาพรวมผลิตภัณฑ์",
   "admin/editor.productSummaryName.title": "ชื่อภาพรวมผลิตภัณฑ์",
   "admin/editor.product-summary-specification-badges.title": "ป้ายข้อกำหนดคุณลักษณะภาพรวมผลิตภัณฑ์",
@@ -72,5 +71,10 @@
   "admin/editor.productSummaryList.installmentCriteria.max-without-interest": "สูงสุดปราศจากดอกเบี้ย",
   "admin/editor.productSummaryList.installmentCriteria.max-with-interest": "สูงสุด",
   "admin/editor.productSummaryList.analyticsListName.title": "ชื่อรายการใน Analytics",
-  "admin/editor.productSummary.trackListName.title": "ควรติดตามชื่อรายการ"
+  "admin/editor.productSummary.trackListName.title": "ควรติดตามชื่อรายการ",
+  "admin/editor.productSummary.sponsoredBadge.title": "ข้อความของแท็กผลิตภัณฑ์ที่ได้รับการสนับสนุนหากมี",
+  "admin/editor.productSummary.sponsoredBadge.position": "ตำแหน่งของแท็กผลิตภัณฑ์ที่ได้รับการสนับสนุนหากมี",
+  "admin/editor.productSummary.sponsoredBadge.position.titleTop": "เหนือชื่อผลิตภัณฑ์",
+  "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft": "ด้านบนของภาชนะบรรจุผลิตภัณฑ์",
+  "admin/editor.productSummary.sponsoredBadge.position.none": "อย่าแสดง"
 }

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -183,11 +183,13 @@ function ProductSummaryCustom({
             {...adsDataProperties}
           >
             <Link className={linkClasses} {...linkProps}>
-              <SponsoredBadge
-                label={sponsoredBadge?.label}
-                showLabel={showSponsoredBadge}
-              />
-              <article className={summaryClasses}>{children}</article>
+              <article className={summaryClasses}>
+                <SponsoredBadge
+                  label={sponsoredBadge?.label}
+                  showLabel={showSponsoredBadge}
+                />
+                {children}
+              </article>
             </Link>
           </section>
         </ProductPriceSimulationWrapper>

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -160,7 +160,7 @@ function ProductSummaryCustom({
   const showSponsoredBadge = shouldShowSponsoredBadge(
     product,
     sponsoredBadge?.position as SponsoredBadgePosition,
-    ['containerTopLeft']
+    'containerTopLeft'
   )
 
   return (

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -10,11 +10,14 @@ import { ProductContextProvider } from 'vtex.product-context'
 import type { ProductTypes } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
+import { SponsoredBadgePosition } from 'vtex.product-summary-context/react/ProductSummaryTypes'
 
 import LocalProductSummaryContext from './ProductSummaryContext'
 import { mapCatalogProductToProductSummary } from './utils/normalize'
 import ProductPriceSimulationWrapper from './components/ProductPriceSimulationWrapper'
 import getAdsDataProperties from './utils/getAdsDataProperties'
+import shouldShowSponsoredBadge from './utils/shouldShowSponsoredBadge'
+import { SponsoredBadge } from './components/SponsoredBadge'
 
 const {
   ProductSummaryProvider,
@@ -46,6 +49,7 @@ function ProductSummaryCustom({
     listName,
     query,
     inView,
+    sponsoredBadge,
   } = useProductSummary()
 
   const dispatch = useProductSummaryDispatch()
@@ -153,6 +157,11 @@ function ProductSummaryCustom({
       }
 
   const adsDataProperties = getAdsDataProperties({ product, position })
+  const showSponsoredBadge = shouldShowSponsoredBadge(
+    product,
+    sponsoredBadge?.position as SponsoredBadgePosition,
+    ['containerTopLeft']
+  )
 
   return (
     <LocalProductSummaryContext.Provider value={oldContextProps}>
@@ -174,6 +183,10 @@ function ProductSummaryCustom({
             {...adsDataProperties}
           >
             <Link className={linkClasses} {...linkProps}>
+              <SponsoredBadge
+                label={sponsoredBadge?.label}
+                showLabel={showSponsoredBadge}
+              />
               <article className={summaryClasses}>{children}</article>
             </Link>
           </section>
@@ -208,6 +221,14 @@ interface Props {
    */
   position?: number
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  /**
+   * The predefined position of the sponsored badge, if applicable.
+   */
+  sponsoredBadgePosition?: SponsoredBadgePosition
+  /**
+   * The label of the sponsored badge, if applicable.
+   */
+  sponsoredBadgeLabel?: string
 }
 
 function ProductSummaryWrapper({
@@ -218,13 +239,21 @@ function ProductSummaryWrapper({
   trackListName = true,
   listName,
   position,
+  sponsoredBadgePosition,
+  sponsoredBadgeLabel,
   classes,
   children,
 }: PropsWithChildren<Props>) {
+  const sponsoredBadge = {
+    position: sponsoredBadgePosition,
+    label: sponsoredBadgeLabel,
+  }
+
   return (
     <ProductSummaryProvider
       product={product}
       listName={trackListName ? listName : undefined}
+      sponsoredBadge={sponsoredBadge}
       isPriceLoading={
         priceBehavior === 'async' || priceBehavior === 'asyncOnly1P'
       }

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -184,10 +184,9 @@ function ProductSummaryCustom({
           >
             <Link className={linkClasses} {...linkProps}>
               <article className={summaryClasses}>
-                <SponsoredBadge
-                  label={sponsoredBadge?.label}
-                  showLabel={showSponsoredBadge}
-                />
+                {showSponsoredBadge ? (
+                  <SponsoredBadge label={sponsoredBadge?.label} />
+                ) : null}
                 {children}
               </article>
             </Link>

--- a/react/ProductSummaryName.tsx
+++ b/react/ProductSummaryName.tsx
@@ -57,7 +57,7 @@ function ProductSummaryName({
   const showSponsoredBadge = shouldShowSponsoredBadge(
     product,
     sponsoredBadge.position as SponsoredBadgePosition,
-    ['titleTop']
+    'titleTop'
   )
 
   const containerClasses = `${handles.nameContainer} flex items-start justify-center pv6`

--- a/react/ProductSummaryName.tsx
+++ b/react/ProductSummaryName.tsx
@@ -3,6 +3,9 @@ import { ProductName } from 'vtex.store-components'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
 import { ProductSummaryContext } from 'vtex.product-summary-context'
+import { SponsoredBadgePosition } from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+import shouldShowSponsoredBadge from './utils/shouldShowSponsoredBadge'
 
 const { useProductSummary } = ProductSummaryContext
 
@@ -36,24 +39,26 @@ interface Props {
    * @default "h3"
    */
   tag?: 'div' | 'h1' | 'h2' | 'h3'
-  sponsoredBadgeLabel: string
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
 }
 
 function ProductSummaryName({
   showFieldsProps = defaultShowFields,
-  sponsoredBadgeLabel,
   tag = 'h3',
   classes,
 }: Props) {
-  const { product } = useProductSummary()
+  const { product, sponsoredBadge } = useProductSummary()
   const { handles } = useCssHandles(CSS_HANDLES, { classes })
   const productName = product?.productName
   // TODO: change ProductSummaryContext to have `selectedSku` field instead of `sku`
   const skuName = product?.sku?.name
   const brandName = product?.brand
 
-  const isSponsored = !!product?.advertisement?.adId
+  const showSponsoredBadge = shouldShowSponsoredBadge(
+    product,
+    sponsoredBadge.position as SponsoredBadgePosition,
+    ['titleTop']
+  )
 
   const containerClasses = `${handles.nameContainer} flex items-start justify-center pv6`
   const wrapperClasses = `${handles.nameWrapper} overflow-hidden c-on-base f5`
@@ -68,8 +73,8 @@ function ProductSummaryName({
         brandNameClass={brandNameClasses}
         skuNameClass={skuNameClasses}
         loaderClass={loaderClasses}
-        showSponsoredBadge={isSponsored}
-        sponsoredBadgeLabel={sponsoredBadgeLabel}
+        showSponsoredBadge={showSponsoredBadge}
+        sponsoredBadgeLabel={sponsoredBadge.label}
         productReferenceClass={handles.productReference}
         name={productName}
         skuName={skuName}

--- a/react/ProductSummaryName.tsx
+++ b/react/ProductSummaryName.tsx
@@ -56,7 +56,7 @@ function ProductSummaryName({
 
   const showSponsoredBadge = shouldShowSponsoredBadge(
     product,
-    sponsoredBadge.position as SponsoredBadgePosition,
+    sponsoredBadge?.position as SponsoredBadgePosition,
     'titleTop'
   )
 
@@ -74,7 +74,7 @@ function ProductSummaryName({
         skuNameClass={skuNameClasses}
         loaderClass={loaderClasses}
         showSponsoredBadge={showSponsoredBadge}
-        sponsoredBadgeLabel={sponsoredBadge.label}
+        sponsoredBadgeLabel={sponsoredBadge?.label}
         productReferenceClass={handles.productReference}
         name={productName}
         skuName={skuName}

--- a/react/components/SponsoredBadge.tsx
+++ b/react/components/SponsoredBadge.tsx
@@ -27,7 +27,7 @@ export const SponsoredBadge = ({
 
   const containerClasses = classNames(
     handles.sponsoredBadgeContainer,
-    'absolute top-0 z-1'
+    'absolute z-1'
   )
 
   const textClasses = classNames(

--- a/react/components/SponsoredBadge.tsx
+++ b/react/components/SponsoredBadge.tsx
@@ -10,20 +10,12 @@ type Props = {
    * The message ID or string for the sponsored label.
    */
   label?: string
-
-  /**
-   * Whether to show the sponsored label text.
-   */
-  showLabel?: boolean
 }
 
 export const SponsoredBadge = ({
   label = 'store/sponsoredBadge.title',
-  showLabel = false,
 }: Props) => {
   const { handles } = useCssHandles(CSS_HANDLES)
-
-  if (!showLabel) return null
 
   const containerClasses = classNames(
     handles.sponsoredBadgeContainer,

--- a/react/components/SponsoredBadge.tsx
+++ b/react/components/SponsoredBadge.tsx
@@ -23,6 +23,8 @@ export const SponsoredBadge = ({
 }: Props) => {
   const { handles } = useCssHandles(CSS_HANDLES)
 
+  if (!showLabel) return null
+
   const containerClasses = classNames(
     handles.sponsoredBadgeContainer,
     'absolute top-0 z-1'
@@ -36,7 +38,7 @@ export const SponsoredBadge = ({
   return (
     <div className={containerClasses}>
       <span className={textClasses}>
-        {showLabel ? <IOMessage id={label} /> : null}
+        <IOMessage id={label} />
       </span>
     </div>
   )

--- a/react/components/SponsoredBadge.tsx
+++ b/react/components/SponsoredBadge.tsx
@@ -1,0 +1,43 @@
+import classNames from 'classnames'
+import React from 'react'
+import { useCssHandles } from 'vtex.css-handles'
+import { IOMessage } from 'vtex.native-types'
+
+const CSS_HANDLES = ['sponsoredBadgeContainer', 'sponsoredBadgeText'] as const
+
+type Props = {
+  /**
+   * The message ID or string for the sponsored label.
+   */
+  label?: string
+
+  /**
+   * Whether to show the sponsored label text.
+   */
+  showLabel?: boolean
+}
+
+export const SponsoredBadge = ({
+  label = 'store/sponsoredBadge.title',
+  showLabel = false,
+}: Props) => {
+  const { handles } = useCssHandles(CSS_HANDLES)
+
+  const containerClasses = classNames(
+    handles.sponsoredBadgeContainer,
+    'absolute top-0 z-1'
+  )
+
+  const textClasses = classNames(
+    handles.sponsoredBadgeText,
+    'c-muted-1 t-mini-s'
+  )
+
+  return (
+    <div className={containerClasses}>
+      <span className={textClasses}>
+        {showLabel ? <IOMessage id={label} /> : null}
+      </span>
+    </div>
+  )
+}

--- a/react/package.json
+++ b/react/package.json
@@ -34,7 +34,7 @@
     "vtex.product-list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list-context@0.4.1/public/@types/vtex.product-list-context",
     "vtex.product-specification-badges": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.3.0/public/@types/vtex.product-specification-badges",
     "vtex.product-summary": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary@2.82.0/public/@types/vtex.product-summary",
-    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.10.0/public/@types/vtex.product-summary-context",
+    "vtex.product-summary-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.11.0/public/@types/vtex.product-summary-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.2/public/@types/vtex.responsive-values",
     "vtex.search-page-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-page-context@0.2.0/public/@types/vtex.search-page-context",

--- a/react/productSummary.css
+++ b/react/productSummary.css
@@ -108,3 +108,9 @@
     transform: rotate(360deg);
   }
 }
+
+.sponsoredBadgeContainer {
+}
+
+.sponsoredBadgeText {
+}

--- a/react/utils/shouldShowSponsoredBadge.ts
+++ b/react/utils/shouldShowSponsoredBadge.ts
@@ -1,0 +1,17 @@
+import {
+  Product,
+  SponsoredBadgePosition,
+} from 'vtex.product-summary-context/react/ProductSummaryTypes'
+
+const shouldShowSponsoredBadge = (
+  product: Product,
+  position: SponsoredBadgePosition,
+  eligiblePositions: SponsoredBadgePosition[]
+) => {
+  const isSponsored = !!product?.advertisement?.adId
+  const showSponsoredBadge = isSponsored && eligiblePositions.includes(position)
+
+  return showSponsoredBadge
+}
+
+export default shouldShowSponsoredBadge

--- a/react/utils/shouldShowSponsoredBadge.ts
+++ b/react/utils/shouldShowSponsoredBadge.ts
@@ -6,10 +6,10 @@ import {
 const shouldShowSponsoredBadge = (
   product: Product,
   position: SponsoredBadgePosition,
-  eligiblePositions: SponsoredBadgePosition[]
+  eligiblePosition: SponsoredBadgePosition
 ) => {
   const isSponsored = !!product?.advertisement?.adId
-  const showSponsoredBadge = isSponsored && eligiblePositions.includes(position)
+  const showSponsoredBadge = isSponsored && position === eligiblePosition
 
   return showSponsoredBadge
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5030,9 +5030,9 @@ verror@1.10.0:
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-specification-badges@0.3.0/public/@types/vtex.product-specification-badges#2df6b189acfabf642504df02d7b8ad406ee90c07"
 
-"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.10.0/public/@types/vtex.product-summary-context":
-  version "0.10.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.10.0/public/@types/vtex.product-summary-context#b19d6782b61766a801e43741659b9f49b4f289ab"
+"vtex.product-summary-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.11.0/public/@types/vtex.product-summary-context":
+  version "0.11.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary-context@0.11.0/public/@types/vtex.product-summary-context#432eadb92b40c903cad2b46ad220b32047c3f7fa"
 
 "vtex.product-summary@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-summary@2.82.0/public/@types/vtex.product-summary":
   version "2.82.0"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -22,9 +22,20 @@
           "default": "store/pricing.from"
         },
         "sponsoredBadgeLabel": {
-          "title": "admin/editor.productSummaryName.sponsoredBadge.title",
+          "title": "admin/editor.productSummary.sponsoredBadge.title",
           "$ref": "app:vtex.native-types#/definitions/text",
           "default": "store/sponsored-badge.label"
+        },
+        "sponsoredBadgePosition": {
+          "title": "admin/editor.productSummary.sponsoredBadge.position",
+          "type": "string",
+          "enum": ["titleTop", "containerTopLeft", "none"],
+          "default": "titleTop",
+          "enumNames": [
+            "admin/editor.productSummary.sponsoredBadge.position.titleTop",
+            "admin/editor.productSummary.sponsoredBadge.position.containerTopLeft",
+            "admin/editor.productSummary.sponsoredBadge.position.none"
+          ]
         },
         "trackListName": {
           "title": "admin/editor.productSummary.trackListName.title",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -52,14 +52,7 @@
     }
   },
   "product-summary-name": {
-    "component": "ProductSummaryName",
-    "content": {
-      "properties": {
-        "sponsoredBadgeLabel": {
-          "$ref": "app:vtex.product-summary#/definitions/ProductSummary/properties/sponsoredBadgeLabel"
-        }
-      }
-    }
+    "component": "ProductSummaryName"
   },
   "product-summary-sku-name": {
     "component": "ProductSummarySKUName"


### PR DESCRIPTION
#### What problem is this solving?

In some stores, the layout doesn't work so well with the sponsored tag begin on top of the product's name.

So, we're now adding the option `containerTop`, that puts the sponsored tag on top of the product container in an absolute position. The store can then manipulate the finer details in their CSS.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://caula--biggy.myvtex.com/camisa?_q=camisa&map=ft&__bindingAddress=biggy.myvtex.com/)

#### Screenshots or example usage:

![Screenshot 2023-12-15 at 16 33 20](https://github.com/vtex-apps/product-summary/assets/15937541/89a34a10-7927-4dc9-85c0-9ab4851d23c2) ![image](https://github.com/vtex-apps/product-summary/assets/15937541/99ec2c10-6111-4554-887d-07016a420f98)


#### Related to / Depends on

Depends on: https://github.com/vtex-apps/product-summary-context/pull/27
