### PR TITLE
Chore: adds intelligent-search as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @vtex-apps/store-framework-devs
+* @vtex-apps/store-framework-devs @vtex-apps/intelligent-search-apps
 docs/ @vtex-apps/technical-writers
 messages/ @vtex-apps/localization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Adds `@vtex-apps/intelligent-search-apps` on CODEOWNERS.
+
 ## [2.87.0] - 2023-11-28
 
 ### Added


### PR DESCRIPTION
#### What problem is this solving?

Adds the [Intelligent Search Apps team](https://github.com/orgs/vtex-apps/teams/intelligent-search-apps) to CODEOWNERS.