### PR TITLE
Limit fetchpriority="high" to 2 images on desktop for improved LCP performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Limited `fetchpriority="high"` to a maximum of 2 images to improve LCP performance in carousels.
+
 ## [2.90.0] - 2024-08-01
 
 ### Added

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -446,7 +446,7 @@ function ProductImage({
         ? positionNumber === 1
           ? 'high'
           : 'low'
-        : positionNumber < 4
+        : positionNumber < 3
         ? 'high'
         : 'low'
     }


### PR DESCRIPTION
#### What problem is this solving?

This change optimizes the fetch priority logic for product images by reducing the number of items with `fetchpriority="high"` on desktop from 4 to 3. This adjustment aligns with Google's recommendation for optimal Largest Contentful Paint (LCP) performance, as outlined in [this article](https://web.dev/articles/optimize-lcp?hl=it#optimize_the_priority_the_resource_is_given).

According to Google:

> Even without lazy loading, browsers don't initially load images with the highest priority because they're not render-blocking resources. You can signal to the browser which resources are more important by using the `fetchpriority` attribute on resources that may benefit from higher priority:
>
> ```html
> <img fetchpriority="high" src="...">
> ```
>
> We recommend setting `fetchpriority="high"` on an `<img>` element if you think it's the page's LCP element. However, setting a high priority on more than one or two images makes prioritization less effective at improving LCP.

By limiting the `fetchpriority="high"` attribute to only the most critical images (3 on desktop), we improve loading efficiency, freeing up bandwidth for other important resources.

#### How to test it?

You can test the change by visiting a product grid in the linked workspace and observing the load times for the images in the first 2 positions. Ensure that only the first 2 images have `fetchpriority="high"` on desktop and the first image on mobile. This can be verified via the browser's DevTools under the "Network" tab.

[Workspace](https://prdev--italiaonlineqa.myvtex.com)

#### Screenshots or example usage:

Production:

<img width="1512" alt="Screenshot 2024-09-13 alle 15 03 09" src="https://github.com/user-attachments/assets/73575ce9-d20d-437b-80cf-3e5ec56a21c0">

Workspace:

<img width="1512" alt="Screenshot 2024-09-13 alle 15 00 51" src="https://github.com/user-attachments/assets/ce823bc4-4a9d-4053-893a-154ff134d1c7">

