### PR TITLE
Add prop fetchpriority to hover image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  ## [Unreleased]
 
+ ### Fixed 
+
+ - Also add prop fetchpriority to hover image
+
 ## [2.90.4] - 2025-04-28
 
 ### Changed

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -500,6 +500,11 @@ function ProductImage({
                 alt={name}
                 className={hoverImageClassname}
                 onError={onError}
+                fetchpriority={
+                fetchpriority === 'byPosition'
+                  ? getFetchPriority(isMobile, position)
+                  : fetchpriority
+              }
               />
             )}
           </div>

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -501,9 +501,9 @@ function ProductImage({
                 className={hoverImageClassname}
                 onError={onError}
                 fetchpriority={
-                fetchpriority === 'byPosition'
-                  ? getFetchPriority(isMobile, position)
-                  : fetchpriority
+                  fetchpriority === 'byPosition'
+                    ? getFetchPriority(isMobile, position)
+                    : fetchpriority
               }
               />
             )}

--- a/react/ProductSummaryImage.tsx
+++ b/react/ProductSummaryImage.tsx
@@ -504,7 +504,7 @@ function ProductImage({
                   fetchpriority === 'byPosition'
                     ? getFetchPriority(isMobile, position)
                     : fetchpriority
-              }
+                }
               />
             )}
           </div>


### PR DESCRIPTION
#### What problem is this solving?

Hover images were not considering the value of the fetchpriority prop added via the site editor.

#### How to test it?

Add the `fetchpriority` prop as `low` via site editor, inspect the image block, and see that only the first one has the prop with the expected value; the image on hover always has the default hover value "auto".  With the fix, all images consider the prop.

#### Screenshots or example usage:

https://lojaspeedo.myvtex.com/
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c77d07d0-50fb-41fd-88f5-dd382e7b0f32" />

Workspace with the fix:
https://juliabraz--lojaspeedo.myvtex.com/

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/d7b2fada-4579-4554-a898-ebd86dc76836" />

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZXpmM2NkazY3OTRheHBscDE3a21sa3Bpb3E4NThsNnhyeXl2N2NhMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3otPoUjeyRisIDxPhK/giphy.gif)
