### PR TITLE
Add aria-label to ProductSummaryCustom link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  ## [Unreleased]
 
+ - Add aria-label to ProductSummaryCustom link
+
 ## [2.90.6] - 2025-07-24
 
  ### Fixed 

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -156,6 +156,7 @@ function ProductSummaryCustom({
         to: href,
         onClick: autocompleteSummary ? actionOnClick : undefined,
         onClickCapture: autocompleteSummary ? undefined : actionOnClick,
+        'aria-label': `View product details for ${product?.productName || 'product'}`,
       }
     : {
         page: 'store.product',
@@ -167,6 +168,7 @@ function ProductSummaryCustom({
         query,
         onClick: autocompleteSummary ? actionOnClick : undefined,
         onClickCapture: autocompleteSummary ? undefined : actionOnClick,
+        'aria-label': `View product details for ${product?.productName || 'product'}`,
       }
 
   const adsDataProperties = getAdsDataProperties({


### PR DESCRIPTION
#### What problem is this solving?

This PR adds an aria label to the link surrounding the products on the PLP, as each `<a>` should have an aria label as there is no visible text alternative.

#### How to test it?

[Workspace](https://richardaccessibility2--colprofr.myvtex.com/toothpaste?layout=grid)

#### Screenshots or example usage:

##### Before

<img width="1494" height="812" alt="Screenshot 2025-08-22 at 11 56 29" src="https://github.com/user-attachments/assets/69429a02-e9bc-432d-a01a-fc3b1aa4ad98" />

##### After

<img width="1496" height="849" alt="Screenshot 2025-08-22 at 11 54 44" src="https://github.com/user-attachments/assets/a6c1cf19-f7e2-4560-b9dd-3e0c862a1169" />

