### PR TITLE
Add focus-visible outline to product link to fix keyboard navigation accessibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  ## [Unreleased]
 
+ ### Added
+
+ - Focus-visible outline when product summary selected using keyboard
+
 ## [2.90.6] - 2025-07-24
 
  ### Fixed 

--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -139,7 +139,7 @@ function ProductSummaryCustom({
   const containerClasses = classNames(
     handles.container,
     handles.containerNormal,
-    'overflow-hidden br3 h-100 w-100 flex flex-column justify-between center tc'
+    'br3 h-100 w-100 flex flex-column justify-between center tc'
   )
 
   const summaryClasses = classNames(
@@ -147,7 +147,7 @@ function ProductSummaryCustom({
     'pointer pt3 pb4 flex flex-column h-100'
   )
 
-  const linkClasses = classNames(handles.clearLink, 'h-100 flex flex-column')
+  const linkClasses = classNames(handles.clearLink, 'h-100 flex flex-column focus-visible:outline-2 focus-visible:outline-blue-500')
 
   const skuId = selectedItem?.itemId ?? product?.sku?.itemId
 


### PR DESCRIPTION
#### What problem is this solving?

Fixes an accessibility issue where users navigating using the keyboard need a visual indicator the product summary element is selected.

#### How to test it?

[Workspace](https://ailbhevtexpr--colprofr.myvtex.com/)

Navigate to the product summary element in the product carousel using the keyboard.

#### Screenshots or example usage:

<img width="1598" height="813" alt="Screenshot 2025-08-26 at 12 00 37" src="https://github.com/user-attachments/assets/e7784a8d-d08c-4f43-9fc0-818109680c83" />

