### PR TITLE
feat: use the new ad event parameter

### DIFF
--- a/react/ProductSummaryCustom.tsx
+++ b/react/ProductSummaryCustom.tsx
@@ -16,7 +16,6 @@ import { useIntl } from 'react-intl'
 import LocalProductSummaryContext from './ProductSummaryContext'
 import ProductPriceSimulationWrapper from './components/ProductPriceSimulationWrapper'
 import { SponsoredBadge } from './components/SponsoredBadge'
-import getAdsDataProperties from './utils/getAdsDataProperties'
 import { mapCatalogProductToProductSummary } from './utils/normalize'
 import shouldShowSponsoredBadge from './utils/shouldShowSponsoredBadge'
 
@@ -40,7 +39,6 @@ function ProductSummaryCustom({
   children,
   href,
   priceBehavior = 'default',
-  placement,
   position,
   classes,
 }: PropsWithChildren<Props>) {
@@ -169,11 +167,7 @@ function ProductSummaryCustom({
         onClickCapture: autocompleteSummary ? undefined : actionOnClick,
       }
 
-  const adsDataProperties = getAdsDataProperties({
-    product,
-    position,
-    placement,
-  })
+  const eventParameters = (product.advertisement as any)?.eventParameters ?? product.advertisement?.adId
 
   const showSponsoredBadge = shouldShowSponsoredBadge(
     product,
@@ -204,7 +198,7 @@ function ProductSummaryCustom({
             onMouseLeave={handleMouseLeave}
             style={{ maxWidth: PRODUCT_SUMMARY_MAX_WIDTH }}
             ref={inViewRef}
-            {...adsDataProperties}
+            data-van-aid={eventParameters}
           >
             <Link className={linkClasses} {...linkProps}>
               <article className={summaryClasses}>

--- a/react/utils/shouldShowSponsoredBadge.ts
+++ b/react/utils/shouldShowSponsoredBadge.ts
@@ -3,12 +3,16 @@ import {
   SponsoredBadgePosition,
 } from 'vtex.product-summary-context/react/ProductSummaryTypes'
 
+interface NewAdvertisement {
+  eventParameters?: string
+}
+
 const shouldShowSponsoredBadge = (
   product: Product,
   position: SponsoredBadgePosition,
   eligiblePosition: SponsoredBadgePosition
 ) => {
-  const isSponsored = !!product?.advertisement?.adId
+  const isSponsored = !!product?.advertisement?.adId || !!(product.advertisement as NewAdvertisement)?.eventParameters
   const showSponsoredBadge = isSponsored && position === eligiblePosition
 
   return showSponsoredBadge


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
We're changing the encoded event parameters from adId to eventParameters, since it's not the ad ID. The data attribute is still using the data-van-aid since that's what the Activity Flow use to track events (to be changed in future).

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
https://adsonboardinglocalhost--biggy.myvtex.com/camisa?__bindingAddress=biggy.myvtex.com/



#### Screenshots or example usage:

<img width="1624" height="1060" alt="image" src="https://github.com/user-attachments/assets/3593a558-1ac6-4cb8-859c-93fb6fea0277" />

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
